### PR TITLE
fix: incorrect version of pglite in lock file

### DIFF
--- a/apps/db-service/package.json
+++ b/apps/db-service/package.json
@@ -9,7 +9,7 @@
     "psql": "psql 'host=localhost port=5432 user=postgres sslmode=verify-ca sslrootcert=ca-cert.pem'"
   },
   "dependencies": {
-    "@electric-sql/pglite": "^0.2.0-alpha.3",
+    "@electric-sql/pglite": "0.2.0-alpha.3",
     "pg-gateway": "^0.2.5-alpha.2"
   },
   "devDependencies": {

--- a/apps/postgres-new/package.json
+++ b/apps/postgres-new/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^0.0.21",
     "@dagrejs/dagre": "^1.1.2",
-    "@electric-sql/pglite": "^0.2.0-alpha.3",
+    "@electric-sql/pglite": "0.2.0-alpha.3",
     "@gregnr/postgres-meta": "^0.82.0-dev.2",
     "@monaco-editor/react": "^4.6.0",
     "@radix-ui/react-accordion": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
     },
     "apps/db-service": {
       "dependencies": {
-        "@electric-sql/pglite": "^0.2.0-alpha.3",
+        "@electric-sql/pglite": "0.2.0-alpha.3",
         "pg-gateway": "^0.2.5-alpha.2"
       },
       "devDependencies": {
@@ -28,7 +28,7 @@
       "dependencies": {
         "@ai-sdk/openai": "^0.0.21",
         "@dagrejs/dagre": "^1.1.2",
-        "@electric-sql/pglite": "^0.2.0-alpha.3",
+        "@electric-sql/pglite": "0.2.0-alpha.3",
         "@gregnr/postgres-meta": "^0.82.0-dev.2",
         "@monaco-editor/react": "^4.6.0",
         "@radix-ui/react-accordion": "^1.2.0",
@@ -442,10 +442,9 @@
       }
     },
     "node_modules/@electric-sql/pglite": {
-      "name": "@gregnr/pglite",
-      "version": "0.2.0-dev.8",
-      "resolved": "https://registry.npmjs.org/@gregnr/pglite/-/pglite-0.2.0-dev.8.tgz",
-      "integrity": "sha512-re5b8EOnQIq22us7aT/BnstyDDGk/M90FdDhxDufrPFAme+9TWpdTSQGFAyBq8BqjhL4O7WHB2M1KTKw02gmUw=="
+      "version": "0.2.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.0-alpha.3.tgz",
+      "integrity": "sha512-1qquX/Swt1MGHguCRIBH+CHN3YQQdCI2SrEf2a1Ln2aGh6UebNtWh2pcTcXerLPP7MBJmD0RnL9FMlU0SHbbyg=="
     },
     "node_modules/@emnapi/runtime": {
       "version": "0.43.1",


### PR DESCRIPTION
The `package-lock.json` didn't reflect the actual version of `pglite` we were meant to be using.