### PR TITLE
Fix chat/IDE expanding beyond screen height for some convos

### DIFF
--- a/apps/postgres-new/components/layout.tsx
+++ b/apps/postgres-new/components/layout.tsx
@@ -49,7 +49,7 @@ export default function Layout({ children }: LayoutProps) {
               there.
             </div>
           )}
-          <div className="flex-1 flex flex-col lg:flex-row">
+          <div className="flex-1 flex flex-col lg:flex-row min-h-0">
             <AnimatePresence initial={false} mode="popLayout">
               {showSidebar && (
                 <m.div


### PR DESCRIPTION
## Before
![image](https://github.com/user-attachments/assets/4dc29c11-38ba-4bc4-a961-63592603fb3c)

## After
![image](https://github.com/user-attachments/assets/2b0a1398-df00-443e-aaa7-b52286fcad88)
