### PR TITLE
fix: missing types

### DIFF
--- a/apps/postgres-new/package.json
+++ b/apps/postgres-new/package.json
@@ -66,6 +66,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "autoprefixer": "^10.4.19",
     "deepmerge": "^4.3.1",
     "eslint": "^8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "@types/react-syntax-highlighter": "^15.5.13",
         "autoprefixer": "^10.4.19",
         "deepmerge": "^4.3.1",
         "eslint": "^8",
@@ -2837,6 +2838,15 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
       "devOptional": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-syntax-highlighter": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz",
+      "integrity": "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }


### PR DESCRIPTION
`@types/react-syntax-highlighter` never got carried over from the original `supabase/supabase` monorepo.