### PR TITLE
PGlite web workers with extension support in v0.2.0

### DIFF
--- a/apps/db-service/package.json
+++ b/apps/db-service/package.json
@@ -9,7 +9,7 @@
     "psql": "psql 'host=localhost port=5432 user=postgres sslmode=verify-ca sslrootcert=ca-cert.pem'"
   },
   "dependencies": {
-    "@electric-sql/pglite": "0.2.0-alpha.3",
+    "@electric-sql/pglite": "0.2.0-alpha.6",
     "pg-gateway": "^0.2.5-alpha.2"
   },
   "devDependencies": {

--- a/apps/postgres-new/lib/db/worker.ts
+++ b/apps/postgres-new/lib/db/worker.ts
@@ -1,0 +1,17 @@
+import { PGlite } from '@electric-sql/pglite'
+import { vector } from '@electric-sql/pglite/vector'
+import { PGliteWorkerOptions, worker } from '@electric-sql/pglite/worker'
+
+worker({
+  async init(options: PGliteWorkerOptions) {
+    return new PGlite({
+      ...options,
+      extensions: {
+        ...options.extensions,
+
+        // vector extension needs to be passed directly in the worker vs. main thread
+        vector,
+      },
+    })
+  },
+})

--- a/apps/postgres-new/package.json
+++ b/apps/postgres-new/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^0.0.21",
     "@dagrejs/dagre": "^1.1.2",
-    "@electric-sql/pglite": "0.2.0-alpha.3",
+    "@electric-sql/pglite": "0.2.0-alpha.6",
     "@gregnr/postgres-meta": "^0.82.0-dev.2",
     "@monaco-editor/react": "^4.6.0",
     "@radix-ui/react-accordion": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
     },
     "apps/db-service": {
       "dependencies": {
-        "@electric-sql/pglite": "0.2.0-alpha.3",
+        "@electric-sql/pglite": "0.2.0-alpha.6",
         "pg-gateway": "^0.2.5-alpha.2"
       },
       "devDependencies": {
@@ -28,7 +28,7 @@
       "dependencies": {
         "@ai-sdk/openai": "^0.0.21",
         "@dagrejs/dagre": "^1.1.2",
-        "@electric-sql/pglite": "0.2.0-alpha.3",
+        "@electric-sql/pglite": "0.2.0-alpha.6",
         "@gregnr/postgres-meta": "^0.82.0-dev.2",
         "@monaco-editor/react": "^4.6.0",
         "@radix-ui/react-accordion": "^1.2.0",
@@ -463,9 +463,9 @@
       }
     },
     "node_modules/@electric-sql/pglite": {
-      "version": "0.2.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.0-alpha.3.tgz",
-      "integrity": "sha512-1qquX/Swt1MGHguCRIBH+CHN3YQQdCI2SrEf2a1Ln2aGh6UebNtWh2pcTcXerLPP7MBJmD0RnL9FMlU0SHbbyg=="
+      "version": "0.2.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.0-alpha.6.tgz",
+      "integrity": "sha512-fKFCLFs3Bz68u6QSvOomKOWcw+GrdK+yyTosXKjRQT4M/DnF1dNZDuLORJj/ZNgRvUTLZPv4dtWzSV5imlalDQ=="
     },
     "node_modules/@emnapi/runtime": {
       "version": "0.43.1",


### PR DESCRIPTION
PGlite v0.2.0 added extension support, but these didn't work with the previous worker model. To fix this PGlite changed the way you create workers which this code implements. 