### PR TITLE
fix: prompt to only use simple configuration for fts

### DIFF
--- a/apps/postgres-new/app/api/chat/route.ts
+++ b/apps/postgres-new/app/api/chat/route.ts
@@ -39,6 +39,8 @@ export async function POST(req: Request) {
       - Check for existing records/conflicts in the table
 
       When querying data, limit to 5 by default.
+
+      When performing FTS, always use 'simple' (languages aren't available).
       
       You also know math. All math equations and expressions must be written in KaTex and must be wrapped in double dollar \`$$\`:
         - Inline: $$\\sqrt{26}$$


### PR DESCRIPTION
Currently only the `simple` configuration works for FTS in PGlite. Other languages cause errors:

![image](https://github.com/user-attachments/assets/de9f29cb-7885-458c-90d5-1d81315afac4)

For now, we'll ask the LLM to only use `simple`.