### PR TITLE
feat: improve initial graph viewport animation

### DIFF
--- a/apps/postgres-new/components/schema/table-graph.tsx
+++ b/apps/postgres-new/components/schema/table-graph.tsx
@@ -64,7 +64,7 @@ export default function TablesGraph({
   )
 
   useEffect(() => {
-    if (tables) {
+    if (tables && tables.length > 0) {
       getGraphDataFromTables(tables).then(({ nodes, edges }) => {
         reactFlowInstance.setNodes(nodes)
         reactFlowInstance.setEdges(edges)


### PR DESCRIPTION
Improves the initial graph viewport to center on contents immediately vs animating from the top left. Subsequent changes (like adding new tables) will continue to animate the viewport as before.

### Before
https://github.com/user-attachments/assets/4e7c5a7b-1afe-4fbb-9c7e-759c09947f8e

### After
https://github.com/user-attachments/assets/a3e2998b-b556-4efe-8e14-6a8127337666