### PR TITLE
feat: move embed to web worker

### DIFF
--- a/apps/postgres-new/lib/embed/index.ts
+++ b/apps/postgres-new/lib/embed/index.ts
@@ -1,0 +1,31 @@
+import { FeatureExtractionPipelineOptions } from '@xenova/transformers'
+import * as Comlink from 'comlink'
+
+type EmbedFn = (typeof import('./worker.ts'))['embed']
+
+let embedFn: EmbedFn
+
+// Wrap embed function in WebWorker via comlink
+function getEmbedFn() {
+  if (embedFn) {
+    return embedFn
+  }
+
+  if (typeof window === 'undefined') {
+    throw new Error('Embed function only available in the browser')
+  }
+
+  const worker = new Worker(new URL('./worker.ts', import.meta.url), { type: 'module' })
+  embedFn = Comlink.wrap<EmbedFn>(worker)
+  return embedFn
+}
+
+/**
+ * Generates an embedding for each text in `texts`.
+ *
+ * @returns An array of vectors.
+ */
+export async function embed(texts: string[], options?: FeatureExtractionPipelineOptions) {
+  const embedFn = getEmbedFn()
+  return await embedFn(texts, options)
+}

--- a/apps/postgres-new/lib/embed/worker.ts
+++ b/apps/postgres-new/lib/embed/worker.ts
@@ -1,0 +1,17 @@
+import { FeatureExtractionPipelineOptions, pipeline } from '@xenova/transformers'
+import * as Comlink from 'comlink'
+
+const embedPromise = pipeline('feature-extraction', 'supabase/gte-small', {
+  quantized: true,
+})
+
+export async function embed(
+  texts: string[],
+  options?: FeatureExtractionPipelineOptions
+): Promise<number[][]> {
+  const embedFn = await embedPromise
+  const tensor = await embedFn(texts, options)
+  return tensor.tolist()
+}
+
+Comlink.expose(embed)

--- a/apps/postgres-new/lib/hooks.ts
+++ b/apps/postgres-new/lib/hooks.ts
@@ -1,6 +1,5 @@
 'use client'
 
-import { FeatureExtractionPipelineOptions, pipeline } from '@xenova/transformers'
 import { generateId } from 'ai'
 import { Chart } from 'chart.js'
 import { codeBlock } from 'common-tags'
@@ -18,6 +17,7 @@ import { createPortal } from 'react-dom'
 import { useDatabaseUpdateMutation } from '~/data/databases/database-update-mutation'
 import { useTablesQuery } from '~/data/tables/tables-query'
 import { getDb } from './db'
+import { embed } from './embed'
 import { loadFile, saveFile } from './files'
 import { SmoothScroller } from './smooth-scroller'
 import { OnToolCall } from './tools'
@@ -382,12 +382,10 @@ export function useOnToolCall(databaseId: string) {
           const { texts } = toolCall.args
 
           try {
-            const tensor = await embed(texts, {
+            const embeddings = await embed(texts, {
               normalize: true,
               pooling: 'mean',
             })
-
-            const embeddings: number[][] = tensor.tolist()
 
             const sql = codeBlock`
               insert into meta.embeddings
@@ -423,15 +421,6 @@ export function useOnToolCall(databaseId: string) {
     },
     [refetchTables, updateDatabase, databaseId, vectorDataTypeId]
   )
-}
-
-const embedPromise = pipeline('feature-extraction', 'supabase/gte-small', {
-  quantized: true,
-})
-
-export async function embed(texts: string | string[], options?: FeatureExtractionPipelineOptions) {
-  const embedFn = await embedPromise
-  return embedFn(texts, options)
 }
 
 export type UseDropZoneOptions = {

--- a/apps/postgres-new/package.json
+++ b/apps/postgres-new/package.json
@@ -29,6 +29,7 @@
     "chartjs-adapter-date-fns": "^3.0.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "comlink": "^4.4.1",
     "common-tags": "^1.8.2",
     "date-fns": "^3.6.0",
     "framer-motion": "^11.2.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "chartjs-adapter-date-fns": "^3.0.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "comlink": "^4.4.1",
         "common-tags": "^1.8.2",
         "date-fns": "^3.6.0",
         "framer-motion": "^11.2.10",
@@ -4246,6 +4247,11 @@
       "bin": {
         "color-support": "bin.js"
       }
+    },
+    "node_modules/comlink": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.1.tgz",
+      "integrity": "sha512-+1dlx0aY5Jo1vHy/tSsIGpSkN4tS9rZSW8FIhG0JH/crs9wwweswIo/POr451r7bZww3hFbPAKnTpimzL/mm4Q=="
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",


### PR DESCRIPTION
Moves `embed` function from Transformers.js into a `WebWorker`. Doing this also prevents SSR warnings when Vercel fails to load Transformers.js server side.