### PR TITLE
Rename "Publish" to "Deploy"

### DIFF
--- a/apps/postgres-new/components/sidebar.tsx
+++ b/apps/postgres-new/components/sidebar.tsx
@@ -23,8 +23,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '~/components/ui/tooltip
 import { useDatabaseDeleteMutation } from '~/data/databases/database-delete-mutation'
 import { useDatabaseUpdateMutation } from '~/data/databases/database-update-mutation'
 import { useDatabasesQuery } from '~/data/databases/databases-query'
-import { usePublishWaitlistCreateMutation } from '~/data/publish-waitlist/publish-waitlist-create-mutation'
-import { useIsOnPublishWaitlistQuery } from '~/data/publish-waitlist/publish-waitlist-query'
+import { useDeployWaitlistCreateMutation } from '~/data/deploy-waitlist/deploy-waitlist-create-mutation'
+import { useIsOnDeployWaitlistQuery } from '~/data/deploy-waitlist/deploy-waitlist-query'
 import { Database } from '~/lib/db'
 import { cn } from '~/lib/utils'
 import { useApp } from './app-provider'
@@ -214,28 +214,28 @@ function DatabaseMenuItem({ database, isActive }: DatabaseMenuItemProps) {
   const { mutateAsync: updateDatabase } = useDatabaseUpdateMutation()
 
   const [isRenaming, setIsRenaming] = useState(false)
-  const [isPublishDialogOpen, setIsPublishDialogOpen] = useState(false)
+  const [isDeployDialogOpen, setIsDeployDialogOpen] = useState(false)
 
-  const { data: isOnPublishWaitlist } = useIsOnPublishWaitlistQuery()
-  const { mutateAsync: joinPublishWaitlist } = usePublishWaitlistCreateMutation()
+  const { data: isOnDeployWaitlist } = useIsOnDeployWaitlistQuery()
+  const { mutateAsync: joinDeployWaitlist } = useDeployWaitlistCreateMutation()
 
   return (
     <>
       <Dialog
-        open={isPublishDialogOpen}
+        open={isDeployDialogOpen}
         onOpenChange={(open) => {
-          setIsPublishDialogOpen(open)
+          setIsDeployDialogOpen(open)
         }}
       >
         <DialogContent className="max-w-2xl">
           <DialogHeader>
-            <DialogTitle>Database publishing is in Private Alpha</DialogTitle>
+            <DialogTitle>Deployments are in Private Alpha</DialogTitle>
             <div className="py-2 border-b" />
           </DialogHeader>
-          <h2 className="font-medium">What is database publishing?</h2>
+          <h2 className="font-medium">What are deployments?</h2>
           <p>
-            Publish your database so that it can be accessed outside the browser using any Postgres
-            client:
+            Deploy your database to a serverless PGlite instance so that it can be accessed outside
+            the browser using any Postgres client:
           </p>
           <CodeBlock
             className="language-curl bg-neutral-800"
@@ -247,11 +247,11 @@ function DatabaseMenuItem({ database, isActive }: DatabaseMenuItemProps) {
           </CodeBlock>
           <div className="flex justify-center items-center mt-3">
             <AnimatePresence initial={false}>
-              {!isOnPublishWaitlist ? (
+              {!isOnDeployWaitlist ? (
                 <button
                   className="px-4 py-3 bg-black text-white rounded-md"
                   onClick={async () => {
-                    await joinPublishWaitlist()
+                    await joinDeployWaitlist()
                   }}
                 >
                   Join Private Alpha
@@ -266,8 +266,8 @@ function DatabaseMenuItem({ database, isActive }: DatabaseMenuItemProps) {
                   initial="hidden"
                   animate="show"
                 >
-                  <h3 className="font-medium mb-2">🎉 You&apos;re on the list!</h3>
-                  <p>We&apos;ll let you know when you have access to publish.</p>
+                  <h3 className="font-medium mb-2">🎉 You&apos;re on the waitlist!</h3>
+                  <p>We&apos;ll send you an email when you have access to deploy.</p>
                 </m.div>
               )}
             </AnimatePresence>
@@ -364,14 +364,14 @@ function DatabaseMenuItem({ database, isActive }: DatabaseMenuItemProps) {
                   onClick={async (e) => {
                     e.preventDefault()
 
-                    setIsPublishDialogOpen(true)
+                    setIsDeployDialogOpen(true)
                     setIsPopoverOpen(false)
                   }}
                   disabled={user === undefined}
                 >
                   <Upload size={16} strokeWidth={2} className="flex-shrink-0" />
 
-                  <span>Publish</span>
+                  <span>Deploy</span>
                 </Button>
                 <Button
                   className="bg-inherit text-destructive-600 justify-start hover:bg-neutral-200 flex gap-3"

--- a/apps/postgres-new/data/deploy-waitlist/deploy-waitlist-create-mutation.ts
+++ b/apps/postgres-new/data/deploy-waitlist/deploy-waitlist-create-mutation.ts
@@ -1,8 +1,8 @@
 import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
 import { createClient } from '~/utils/supabase/client'
-import { getIsOnPublishWaitlistQueryKey } from './publish-waitlist-query'
+import { getIsOnDeployWaitlistQueryKey } from './deploy-waitlist-query'
 
-export const usePublishWaitlistCreateMutation = ({
+export const useDeployWaitlistCreateMutation = ({
   onSuccess,
   onError,
   ...options
@@ -13,7 +13,7 @@ export const usePublishWaitlistCreateMutation = ({
     mutationFn: async () => {
       const supabase = createClient()
 
-      const { error } = await supabase.from('publish_waitlist').insert({})
+      const { error } = await supabase.from('deploy_waitlist').insert({})
 
       if (error) {
         throw error
@@ -21,7 +21,7 @@ export const usePublishWaitlistCreateMutation = ({
     },
     async onSuccess(data, variables, context) {
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: getIsOnPublishWaitlistQueryKey() }),
+        queryClient.invalidateQueries({ queryKey: getIsOnDeployWaitlistQueryKey() }),
       ])
       return onSuccess?.(data, variables, context)
     },

--- a/apps/postgres-new/data/deploy-waitlist/deploy-waitlist-query.ts
+++ b/apps/postgres-new/data/deploy-waitlist/deploy-waitlist-query.ts
@@ -1,14 +1,14 @@
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { createClient } from '~/utils/supabase/client'
 
-export const useIsOnPublishWaitlistQuery = (
+export const useIsOnDeployWaitlistQuery = (
   options: Omit<UseQueryOptions<boolean, Error>, 'queryKey' | 'queryFn'> = {}
 ) => {
   const supabase = createClient()
 
   return useQuery<boolean, Error>({
     ...options,
-    queryKey: getIsOnPublishWaitlistQueryKey(),
+    queryKey: getIsOnDeployWaitlistQueryKey(),
     queryFn: async () => {
       const { data, error } = await supabase.auth.getUser()
       if (error) {
@@ -17,7 +17,7 @@ export const useIsOnPublishWaitlistQuery = (
       const { user } = data
 
       const { data: waitlistRecord, error: waitlistError } = await supabase
-        .from('publish_waitlist')
+        .from('deploy_waitlist')
         .select('*')
         .eq('user_id', user.id)
         .maybeSingle()
@@ -33,4 +33,4 @@ export const useIsOnPublishWaitlistQuery = (
   })
 }
 
-export const getIsOnPublishWaitlistQueryKey = () => ['publish-waitlist']
+export const getIsOnDeployWaitlistQueryKey = () => ['deploy-waitlist']

--- a/apps/postgres-new/utils/supabase/db-types.ts
+++ b/apps/postgres-new/utils/supabase/db-types.ts
@@ -34,7 +34,7 @@ export type Database = {
   }
   public: {
     Tables: {
-      publish_waitlist: {
+      deploy_waitlist: {
         Row: {
           created_at: string
           id: number
@@ -52,7 +52,7 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "publish_waitlist_user_id_fkey"
+            foreignKeyName: "deploy_waitlist_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "users"

--- a/supabase/migrations/20240807150202_rename_publish_waitlist.sql
+++ b/supabase/migrations/20240807150202_rename_publish_waitlist.sql
@@ -1,0 +1,4 @@
+alter table public.publish_waitlist
+rename to deploy_waitlist;
+
+alter table public.deploy_waitlist rename constraint publish_waitlist_user_id_fkey to deploy_waitlist_user_id_fkey;


### PR DESCRIPTION
Renames "Publish" to "Deploy" which better represents what it really does, and lets us reserve "Publish" for actual database publishing, ie. sharing a browser link to `postgres.new/db/<id>` for others to see, CodeSandbox style.

![image](https://github.com/user-attachments/assets/fd60fe73-a7c0-41fa-987b-5c1f38137794)

![image](https://github.com/user-attachments/assets/432cffd2-df58-41a9-9d13-0187e7935b2d)

![image](https://github.com/user-attachments/assets/e0f1291b-d71a-4a2f-8201-76bcee772d01)
