### PR TITLE
feat: focus input after authentication and clicking 'new database'

### DIFF
--- a/apps/postgres-new/components/chat.tsx
+++ b/apps/postgres-new/components/chat.tsx
@@ -9,6 +9,7 @@ import {
   FormEventHandler,
   useCallback,
   useEffect,
+  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -47,7 +48,7 @@ export function getInitialMessages(tables: TablesData): Message[] {
 }
 
 export default function Chat() {
-  const { user, isLoadingUser } = useApp()
+  const { user, isLoadingUser, focusRef } = useApp()
   const [inputFocusState, setInputFocusState] = useState(false)
 
   const {
@@ -174,6 +175,15 @@ export default function Chat() {
 
   const isSubmitEnabled =
     !isLoadingMessages && !isLoadingSchema && Boolean(input.trim()) && user !== undefined
+
+  // Create imperative handle that can be used to focus the input anywhere in the app
+  useImperativeHandle(focusRef, () => ({
+    focus() {
+      if (inputRef.current) {
+        inputRef.current.focus()
+      }
+    },
+  }))
 
   return (
     <div ref={dropZoneRef} className="h-full flex flex-col items-stretch relative">

--- a/apps/postgres-new/components/sidebar.tsx
+++ b/apps/postgres-new/components/sidebar.tsx
@@ -40,7 +40,7 @@ import {
 } from './ui/dropdown-menu'
 
 export default function Sidebar() {
-  const { user, signOut } = useApp()
+  const { user, signOut, focusRef } = useApp()
   let { id: currentDatabaseId } = useParams<{ id: string }>()
   const router = useRouter()
   const { data: databases, isLoading: isLoadingDatabases } = useDatabasesQuery()
@@ -84,6 +84,7 @@ export default function Sidebar() {
                 <Button
                   onClick={() => {
                     router.push('/')
+                    focusRef.current?.focus()
                   }}
                   className="gap-2"
                 >
@@ -176,6 +177,7 @@ export default function Sidebar() {
                     size={'icon'}
                     onClick={() => {
                       router.push('/')
+                      focusRef.current?.focus()
                     }}
                   >
                     <PackagePlus size={14} />


### PR DESCRIPTION
Adds ability to focus the primary input (AI chat) from anywhere in the app. Specifically allows us to:
- Focus input after GitHub authentication (includes redirects)
- Focus input after clicking "New Database"