### PR TITLE
fix: initial animation on graph viewport

### DIFF
--- a/apps/postgres-new/components/schema/table-graph.tsx
+++ b/apps/postgres-new/components/schema/table-graph.tsx
@@ -73,7 +73,10 @@ export default function TablesGraph({
 
         // `fitView` needs to happen during next event tick
         setTimeout(() => fitView(isFirstLoad ? 0 : 500), 0)
-        setIsFirstLoad(false)
+
+        if (tables.length > 0) {
+          setIsFirstLoad(false)
+        }
       })
     }
   }, [reactFlowInstance, tables, resolvedTheme, fitView, isFirstLoad])


### PR DESCRIPTION
Fixes initial viewport animation on table graph to center on the table immediately rather than slide from top left.