### PR TITLE
chore: upgrade pglite@0.2.0-alpha.9

### DIFF
--- a/apps/db-service/package.json
+++ b/apps/db-service/package.json
@@ -9,7 +9,7 @@
     "psql": "psql 'host=localhost port=5432 user=postgres sslmode=verify-ca sslrootcert=ca-cert.pem'"
   },
   "dependencies": {
-    "@electric-sql/pglite": "0.2.0-alpha.6",
+    "@electric-sql/pglite": "0.2.0-alpha.9",
     "pg-gateway": "^0.2.5-alpha.2"
   },
   "devDependencies": {

--- a/apps/postgres-new/package.json
+++ b/apps/postgres-new/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@ai-sdk/openai": "^0.0.21",
     "@dagrejs/dagre": "^1.1.2",
-    "@electric-sql/pglite": "0.2.0-alpha.6",
+    "@electric-sql/pglite": "0.2.0-alpha.9",
     "@gregnr/postgres-meta": "^0.82.0-dev.2",
     "@monaco-editor/react": "^4.6.0",
     "@radix-ui/react-accordion": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
     },
     "apps/db-service": {
       "dependencies": {
-        "@electric-sql/pglite": "0.2.0-alpha.6",
+        "@electric-sql/pglite": "0.2.0-alpha.9",
         "pg-gateway": "^0.2.5-alpha.2"
       },
       "devDependencies": {
@@ -28,7 +28,7 @@
       "dependencies": {
         "@ai-sdk/openai": "^0.0.21",
         "@dagrejs/dagre": "^1.1.2",
-        "@electric-sql/pglite": "0.2.0-alpha.6",
+        "@electric-sql/pglite": "0.2.0-alpha.9",
         "@gregnr/postgres-meta": "^0.82.0-dev.2",
         "@monaco-editor/react": "^4.6.0",
         "@radix-ui/react-accordion": "^1.2.0",
@@ -466,9 +466,9 @@
       }
     },
     "node_modules/@electric-sql/pglite": {
-      "version": "0.2.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.0-alpha.6.tgz",
-      "integrity": "sha512-fKFCLFs3Bz68u6QSvOomKOWcw+GrdK+yyTosXKjRQT4M/DnF1dNZDuLORJj/ZNgRvUTLZPv4dtWzSV5imlalDQ=="
+      "version": "0.2.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.0-alpha.9.tgz",
+      "integrity": "sha512-euiFGNa2NtwF2DdXCojZXtbBvhkd1ZgG/jfMimAdHp4h2kzz/bqvRYiLoH41zmFCc4XeaQyMEhuVmbdwb67hBA=="
     },
     "node_modules/@emnapi/runtime": {
       "version": "0.43.1",


### PR DESCRIPTION
Upgrades PGlite to `v0.2.0-alpha.9` which fixes issues uploading large CSV files.