### PR TITLE
feat: remove delete policy from deploy waitlist

### DIFF
--- a/supabase/migrations/20240810203851_remove_waitlist_delete_policy.sql
+++ b/supabase/migrations/20240810203851_remove_waitlist_delete_policy.sql
@@ -1,0 +1,1 @@
+drop policy if exists "Users can only delete their own waitlist record." on public.deploy_waitlist;


### PR DESCRIPTION
Removes the `delete` RLS policy for the deploy waitlist since deletes never need to happen by users themselves (better practice to remove the ability entirely until we need it).