### PR TITLE
feat: hide mobile

### DIFF
--- a/apps/postgres-new/components/chat.tsx
+++ b/apps/postgres-new/components/chat.tsx
@@ -302,7 +302,7 @@ export default function Chat() {
             {user ? (
               <m.h3
                 layout
-                className="text-2xl font-light"
+                className="text-2xl font-light text-center"
                 variants={{
                   hidden: { opacity: 0, y: 10 },
                   show: { opacity: 1, y: 0 },

--- a/apps/postgres-new/components/workspace.tsx
+++ b/apps/postgres-new/components/workspace.tsx
@@ -115,7 +115,7 @@ export default function Workspace({
         visibility,
       }}
     >
-      <div className="w-full h-full flex flex-col lg:flex-row gap-8">
+      <div className="w-full h-full hidden lg:flex flex-col lg:flex-row gap-8">
         <IDE className="flex-1 h-full p-3 sm:py-6 sm:pl-6">
           <Chat />
         </IDE>
@@ -124,6 +124,9 @@ export default function Workspace({
             <Chat />
           </div>
         )}
+      </div>
+      <div className="w-full h-full flex lg:hidden justify-center items-center p-6 text-center">
+        Please connect from a laptop or desktop to use postgres.new.
       </div>
     </WorkspaceContext.Provider>
   )


### PR DESCRIPTION
Hides the app on non-desktop devices until we can sort out mobile-specific bugs.

![image](https://github.com/user-attachments/assets/dce3d4a2-aef5-4d91-9c2c-01667bb6128c)