### PR TITLE
fix(sidebar): :bug: conditionally hide signout button when collapsed

### DIFF
--- a/apps/postgres-new/components/sidebar.tsx
+++ b/apps/postgres-new/components/sidebar.tsx
@@ -200,6 +200,7 @@ export default function Sidebar() {
                 <p>Toggle theme</p>
               </TooltipContent>
             </Tooltip>
+            {user && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <m.div layout="position" layoutId="sign-out-button">
@@ -218,6 +219,7 @@ export default function Sidebar() {
                 <p>Sign out</p>
               </TooltipContent>
             </Tooltip>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

- Sign out button appears even when the current state is non-logged in and the sidebar is collapsed

## What is the new behavior?

- Conditionally hide the signout button when the sidebar is collapsed