### PR TITLE
Fix CSV MIME type issue when uploading

### DIFF
--- a/apps/postgres-new/components/chat.tsx
+++ b/apps/postgres-new/components/chat.tsx
@@ -73,7 +73,16 @@ export default function Chat() {
 
   const sendCsv = useCallback(
     async (file: File) => {
-      if (file.type !== 'text/csv') {
+
+      // List of acceptable MIME types for CSV files
+      const validCsvMimeTypes = [
+        'text/csv', 
+        'application/vnd.ms-excel', 
+        'application/csv',
+        'text/plain' 
+      ];
+
+      if (!validCsvMimeTypes.includes(file.type)) {
         // Add an artificial tool call requesting the CSV
         // with an error indicating the file wasn't a CSV
         appendMessage({


### PR DESCRIPTION
## What kind of change does this PR introduce?

Upload wasn't working so I added a few more file types:
-'text/csv',
-'application/vnd.ms-excel',
-'application/csv',
-'text/plain'

## What is the current behavior?

Uploading a CSV would give you `It seems the file you are trying to upload is still in the 'application/vnd.ms-excel format'. Please convert your file to CSV format and try uploading it again.` as message on a Windows machine. 

## Additional context

This might cause some security issues.