### PR TITLE
feat: add max query row count to mitigate LLM abuse

### DIFF
--- a/apps/postgres-new/app/api/chat/route.ts
+++ b/apps/postgres-new/app/api/chat/route.ts
@@ -1,7 +1,7 @@
 import { openai } from '@ai-sdk/openai'
 import { ToolInvocation, convertToCoreMessages, streamText } from 'ai'
 import { codeBlock } from 'common-tags'
-import { convertToCoreTools, tools } from '~/lib/tools'
+import { convertToCoreTools, maxRowLimit, tools } from '~/lib/tools'
 
 // Allow streaming responses up to 30 seconds
 export const maxDuration = 30
@@ -39,7 +39,8 @@ export async function POST(req: Request) {
       - Make the data realistic, including joined data
       - Check for existing records/conflicts in the table
 
-      When querying data, limit to 5 by default.
+      When querying data, limit to 5 by default. The maximum number of rows you're allowed to fetch is ${maxRowLimit} (to protect AI from token abuse).
+      If the user needs to fetch more than ${maxRowLimit} rows at once, they can export the query as a CSV.
 
       When performing FTS, always use 'simple' (languages aren't available).
 

--- a/apps/postgres-new/lib/tools.ts
+++ b/apps/postgres-new/lib/tools.ts
@@ -17,6 +17,11 @@ function result<T extends z.ZodTypeAny>(schema: T) {
 }
 
 /**
+ * The maximum SQL result row limit to prevent overloading LLM.
+ */
+export const maxRowLimit = 100
+
+/**
  * Central location for all LLM tools including their
  * description, arg schema, and result schema.
  *


### PR DESCRIPTION
## Problem
All SQL query results are returned to the LLM. Currently there is no limit on query result row count, which means nothing stops you from:
1. importing a CSV with 1000s of rows
2. asking AI for a select * with no limit
3. returning a massive list of results back to the LLM (each using multiple tokens)

We need to add a guard to limit the number of records from these queries to:
- prevent massive token costs
- prevent performance from degrading
- hitting the LLM's max context limit (128k tokens today)

## Solution
Enforce a hard limit of 100 rows returned. The LLM is prompted to not go over this limit, and if it still does, an error is thrown and forwarded back to the LLM. 100 was chosen as a count that is still big enough to produce meaningful results (usually aggregated data for charts), but not so big to overwhelm the LLM.

As an escape hatch, users can request the LLM export the query as a CSV, at which point it will happily return more than 100 rows.