### PR TITLE
feat: limit message context sent to llm

### DIFF
--- a/apps/postgres-new/app/api/chat/route.ts
+++ b/apps/postgres-new/app/api/chat/route.ts
@@ -1,7 +1,7 @@
 import { openai } from '@ai-sdk/openai'
 import { ToolInvocation, convertToCoreMessages, streamText } from 'ai'
 import { codeBlock } from 'common-tags'
-import { convertToCoreTools, tools } from '~/lib/tools'
+import { convertToCoreTools, maxMessageContext, tools } from '~/lib/tools'
 
 // Allow streaming responses up to 30 seconds
 export const maxDuration = 30
@@ -14,6 +14,9 @@ type Message = {
 
 export async function POST(req: Request) {
   const { messages }: { messages: Message[] } = await req.json()
+
+  // Trim the message context sent to the LLM to mitigate token abuse
+  const trimmedMessageContext = messages.slice(-maxMessageContext)
 
   const result = await streamText({
     system: codeBlock`
@@ -58,7 +61,7 @@ export async function POST(req: Request) {
       Feel free to suggest corrections for suspected typos.
     `,
     model: openai('gpt-4o-2024-08-06'),
-    messages: convertToCoreMessages(messages),
+    messages: convertToCoreMessages(trimmedMessageContext),
     tools: convertToCoreTools(tools),
   })
 

--- a/apps/postgres-new/lib/tools.ts
+++ b/apps/postgres-new/lib/tools.ts
@@ -17,6 +17,11 @@ function result<T extends z.ZodTypeAny>(schema: T) {
 }
 
 /**
+ * The maximum number of messages from the chat history to send to the LLM.
+ */
+export const maxMessageContext = 30
+
+/**
  * Central location for all LLM tools including their
  * description, arg schema, and result schema.
  *


### PR DESCRIPTION
## Problem
In an ideal world, we send as much context to the LLM as possible so that it has the most amount of information to help respond to your questions/tasks. Unfortunately token costs grow quadratically for every message added to the chat, since you need to send all previous messages each time.

## Solution
To prevent token costs from blowing out of proportion, we can limit the max number of previous messages to send to the LLM as context each request.

_Important:_ this does not mean the actual message history is limited on the frontend. This is strictly referring to the sliding window of the past X messages being sent to the LLM as context each time.

This PR sets this message context limit to 30 messages. The consequence of this change is that the model will have no memory of messages older than 30 messages, so will be unable to answer a questions or refer to information from more than 30 messages back.

30 messages was chosen as a reasonable amount of context to help the user accomplish whatever task they are working on in that moment, but not be too much that irrelevant/stale messages are sent every time (adding large costs) with little value.

## Future
In the future, we can consider summarizing old messages before trimming the context so that the model at least has some history to refer to. Rewriting message history can get tricky though, so this will need more thought.