### PR TITLE
feat: remove initial tool call messages

### DIFF
--- a/apps/postgres-new/components/chat.tsx
+++ b/apps/postgres-new/components/chat.tsx
@@ -26,27 +26,6 @@ import ChatMessage from './chat-message'
 import SignInButton from './sign-in-button'
 import { useWorkspace } from './workspace'
 
-export function getInitialMessages(tables: TablesData): Message[] {
-  return [
-    // An artificial tool call containing the DB schema
-    // as if it was already called by the LLM
-    {
-      id: generateId(),
-      role: 'assistant',
-      content: '',
-      toolInvocations: [
-        {
-          state: 'result',
-          toolCallId: generateId(),
-          toolName: 'getDatabaseSchema',
-          args: {},
-          result: tables,
-        },
-      ],
-    },
-  ]
-}
-
 export default function Chat() {
   const { user, isLoadingUser, focusRef, setIsSignInDialogOpen } = useApp()
   const [inputFocusState, setInputFocusState] = useState(false)


### PR DESCRIPTION
## Background
When this project was first created as a POC, chat message history did not persist, but your DB tables did. So we added a hidden initial tool call message at the beginning of every conversation that told the LLM which tables were available. This allowed the LLM to know your schema right away without asking.

Since making the POC, we added the ability to persist chat messages which makes this feature unnecessary (DB will always have no tables at the start of the conversation).

## Change
Remove these initial hidden tool call messages. They add a decent amount of tokens every request, so if they don't have a good purpose anymore lets remove them.