### PR TITLE
feat: rate limits

### DIFF
--- a/apps/postgres-new/.env.example
+++ b/apps/postgres-new/.env.example
@@ -3,3 +3,7 @@ NEXT_PUBLIC_SUPABASE_URL="<supabase-api-url>"
 NEXT_PUBLIC_IS_PREVIEW=true
 
 OPENAI_API_KEY="<openai-api-key>"
+
+# Vercel KV (local Docker available)
+KV_REST_API_URL="http://localhost:8080"
+KV_REST_API_TOKEN="local_token"

--- a/apps/postgres-new/README.md
+++ b/apps/postgres-new/README.md
@@ -46,7 +46,16 @@ From this directory (`./apps/postgres-new`):
    ```shell
    echo 'OPENAI_API_KEY="<openai-api-key>"' >> .env.local
    ```
-5. Start Next.js development server:
+5. Start local Redis containers (used for rate limiting). Serves an API on port 8080:
+   ```shell
+   docker compose up -d
+   ```
+6. Store local KV (Redis) vars. Use these exact values:
+   ```shell
+   echo 'KV_REST_API_URL="http://localhost:8080"' >> .env.local
+   echo 'KV_REST_API_TOKEN="local_token"' >> .env.local
+   ```
+7. Start Next.js development server:
    ```shell
    npm run dev
    ```

--- a/apps/postgres-new/components/app-provider.tsx
+++ b/apps/postgres-new/components/app-provider.tsx
@@ -28,6 +28,7 @@ export default function AppProvider({ children }: AppProps) {
   const [isLoadingUser, setIsLoadingUser] = useState(true)
   const [user, setUser] = useState<User>()
   const [isSignInDialogOpen, setIsSignInDialogOpen] = useState(false)
+  const [isRateLimited, setIsRateLimited] = useState(false)
 
   const focusRef = useRef<FocusHandle>(null)
 
@@ -113,6 +114,8 @@ export default function AppProvider({ children }: AppProps) {
         signOut,
         isSignInDialogOpen,
         setIsSignInDialogOpen,
+        isRateLimited,
+        setIsRateLimited,
         focusRef,
         isPreview,
         dbManager,
@@ -136,6 +139,8 @@ export type AppContextValues = {
   signOut: () => Promise<void>
   isSignInDialogOpen: boolean
   setIsSignInDialogOpen: (open: boolean) => void
+  isRateLimited: boolean
+  setIsRateLimited: (limited: boolean) => void
   focusRef: RefObject<FocusHandle>
   isPreview: boolean
   dbManager?: DbManager

--- a/apps/postgres-new/components/chat.tsx
+++ b/apps/postgres-new/components/chat.tsx
@@ -3,7 +3,7 @@
 import { Message, generateId } from 'ai'
 import { useChat } from 'ai/react'
 import { AnimatePresence, m } from 'framer-motion'
-import { ArrowDown, ArrowUp, Paperclip, Square } from 'lucide-react'
+import { ArrowDown, ArrowUp, Flame, Paperclip, Square } from 'lucide-react'
 import {
   ChangeEvent,
   FormEventHandler,
@@ -48,7 +48,7 @@ export function getInitialMessages(tables: TablesData): Message[] {
 }
 
 export default function Chat() {
-  const { user, isLoadingUser, focusRef, setIsSignInDialogOpen } = useApp()
+  const { user, isLoadingUser, focusRef, setIsSignInDialogOpen, isRateLimited } = useApp()
   const [inputFocusState, setInputFocusState] = useState(false)
 
   const {
@@ -261,6 +261,32 @@ export default function Chat() {
                   isLast={i === messages.length - 1}
                 />
               ))}
+              <AnimatePresence initial={false}>
+                {isRateLimited && !isLoading && (
+                  <m.div
+                    layout="position"
+                    className="flex flex-col gap-4 justify-start items-center max-w-96 p-4 bg-destructive rounded-md text-sm"
+                    variants={{
+                      hidden: { scale: 0 },
+                      show: { scale: 1, transition: { delay: 0.5 } },
+                    }}
+                    initial="hidden"
+                    animate="show"
+                    exit="hidden"
+                  >
+                    <Flame size={64} strokeWidth={1} />
+                    <div className="flex flex-col items-center text-start gap-4">
+                      <h3 className="font-bold">Hang tight!</h3>
+                      <p>
+                        We&apos;re seeing a lot of AI traffic from your end and need to temporarily
+                        pause your chats to make sure our servers don&apos;t melt.
+                      </p>
+
+                      <p>Have a quick coffee break and try again in a few minutes!</p>
+                    </div>
+                  </m.div>
+                )}
+              </AnimatePresence>
               <AnimatePresence>
                 {isLoading && (
                   <m.div

--- a/apps/postgres-new/components/workspace.tsx
+++ b/apps/postgres-new/components/workspace.tsx
@@ -8,6 +8,7 @@ import { useTablesQuery } from '~/data/tables/tables-query'
 import { useOnToolCall } from '~/lib/hooks'
 import { useBreakpoint } from '~/lib/use-breakpoint'
 import { ensureMessageId, ensureToolResult } from '~/lib/util'
+import { useApp } from './app-provider'
 import Chat, { getInitialMessages } from './chat'
 import IDE from './ide'
 
@@ -51,6 +52,7 @@ export default function Workspace({
   onReply,
   onCancelReply,
 }: WorkspaceProps) {
+  const { setIsRateLimited } = useApp()
   const isSmallBreakpoint = useBreakpoint('lg')
   const onToolCall = useOnToolCall(databaseId)
   const { mutateAsync: saveMessage } = useMessageCreateMutation(databaseId)
@@ -75,6 +77,9 @@ export default function Workspace({
       // Order is important here
       await onReply?.(message, append)
       await saveMessage({ message })
+    },
+    async onResponse(response) {
+      setIsRateLimited(response.status === 429)
     },
   })
 

--- a/apps/postgres-new/docker-compose.yml
+++ b/apps/postgres-new/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  redis:
+    image: redis
+  local-vercel-kv:
+    image: hiett/serverless-redis-http:latest
+    ports:
+      - 8080:80
+    environment:
+      SRH_MODE: env
+      SRH_TOKEN: local_token
+      SRH_CONNECTION_STRING: redis://redis:6379

--- a/apps/postgres-new/package.json
+++ b/apps/postgres-new/package.json
@@ -26,6 +26,8 @@
     "@supabase/ssr": "^0.4.0",
     "@supabase/supabase-js": "^2.45.0",
     "@tanstack/react-query": "^5.45.0",
+    "@upstash/ratelimit": "^2.0.1",
+    "@vercel/kv": "^2.0.0",
     "@xenova/transformers": "^2.17.2",
     "ai": "^3.2.8",
     "chart.js": "^4.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,6 @@
       "workspaces": [
         "apps/*"
       ],
-      "dependencies": {
-        "@upstash/ratelimit": "^2.0.1",
-        "@vercel/kv": "^2.0.0"
-      },
       "devDependencies": {
         "supabase": "^1.187.8"
       }
@@ -46,6 +42,8 @@
         "@supabase/ssr": "^0.4.0",
         "@supabase/supabase-js": "^2.45.0",
         "@tanstack/react-query": "^5.45.0",
+        "@upstash/ratelimit": "^2.0.1",
+        "@vercel/kv": "^2.0.0",
         "@xenova/transformers": "^2.17.2",
         "ai": "^3.2.8",
         "chart.js": "^4.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "workspaces": [
         "apps/*"
       ],
+      "dependencies": {
+        "@upstash/ratelimit": "^2.0.1",
+        "@vercel/kv": "^2.0.0"
+      },
       "devDependencies": {
         "supabase": "^1.187.8"
       }
@@ -3118,6 +3122,44 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.1.tgz",
+      "integrity": "sha512-J+0hlkvWUjlVrjcBQhWx7gbaUGsvFF59i+GAx7YQk8L0E0MQ93xzCPu02uaXhGDJGkxiar7nRRPqj3hs+CdAJg==",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.34.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.34.0.tgz",
+      "integrity": "sha512-TrXNoJLkysIl8SBc4u9bNnyoFYoILpCcFJcLyWCccb/QSUmaVKdvY0m5diZqc3btExsapcMbaw/s/wh9Sf1pJw==",
+      "dependencies": {
+        "crypto-js": "^4.2.0"
+      }
+    },
+    "node_modules/@vercel/kv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/kv/-/kv-2.0.0.tgz",
+      "integrity": "sha512-zdVrhbzZBYo5d1Hfn4bKtqCeKf0FuzW8rSHauzQVMUgv1+1JOwof2mWcBuI+YMJy8s0G0oqAUfQ7HgUDzb8EbA==",
+      "dependencies": {
+        "@upstash/redis": "^1.31.3"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.4.33",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,5 @@
   ],
   "devDependencies": {
     "supabase": "^1.187.8"
-  },
-  "dependencies": {
-    "@upstash/ratelimit": "^2.0.1",
-    "@vercel/kv": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,14 @@
   "scripts": {
     "dev": "npm run dev --workspace postgres-new"
   },
-  "workspaces": ["apps/*"],
+  "workspaces": [
+    "apps/*"
+  ],
   "devDependencies": {
     "supabase": "^1.187.8"
+  },
+  "dependencies": {
+    "@upstash/ratelimit": "^2.0.1",
+    "@vercel/kv": "^2.0.0"
   }
 }


### PR DESCRIPTION
## Problem
As with any free product, most users use it as intended, but a small number take advantage and abuse it.

## Solution
This update introduces standard rate limiting to the app. Current limits are:
- **Input tokens:** 1000000/30m
- **Output tokens:** 10000/30m

After reaching this limit the user will see:
![image](https://github.com/user-attachments/assets/27297f84-acae-440c-a3db-dacbace0ce6f)

Until the next reset period.