### PR TITLE
fix(chat): prevent Enter key action during IME composition

### DIFF
--- a/apps/postgres-new/components/chat.tsx
+++ b/apps/postgres-new/components/chat.tsx
@@ -506,6 +506,11 @@ export default function Chat() {
                 return
               }
 
+              if ( e.nativeEvent.isComposing )
+              {
+                return
+              }
+
               if (e.key === 'Enter' && !e.shiftKey) {
                 e.preventDefault()
                 if (!isLoading && isSubmitEnabled) {

--- a/apps/postgres-new/components/chat.tsx
+++ b/apps/postgres-new/components/chat.tsx
@@ -506,12 +506,7 @@ export default function Chat() {
                 return
               }
 
-              if ( e.nativeEvent.isComposing )
-              {
-                return
-              }
-
-              if (e.key === 'Enter' && !e.shiftKey) {
+              if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
                 e.preventDefault()
                 if (!isLoading && isSubmitEnabled) {
                   handleFormSubmit(e)


### PR DESCRIPTION
## issue

- https://github.com/supabase-community/postgres-new/issues/83

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently, when typing in languages that use Input Method Editors (IMEs) such as Japanese, pressing the Enter key to confirm the IME conversion unintentionally sends the message. This occurs because the system doesn't distinguish between normal Enter key presses and those used for IME conversion confirmation.

## What is the new behavior?

This PR adds an `isComposing` check to the `keydown` event handler. This prevents the message from being sent while the user is still in the process of IME composition. Here's a snippet of the modified code:

```ts
onKeyDown={(e) => {
  if (!(e.target instanceof HTMLTextAreaElement)) {
    return
  }

  if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
  // ... rest of the handler
```

This change ensures that the Enter key only sends the message when it's not being used for IME composition confirmation.

## Additional context

This bug fix improves the user experience for those typing in languages that use IMEs, such as Japanese, Chinese, and Korean. It prevents accidental message sending during the composition process, allowing for a smoother typing experience in these languages.