### PR TITLE
feat: enable all supported extensions

### DIFF
--- a/apps/postgres-new/lib/db/worker.ts
+++ b/apps/postgres-new/lib/db/worker.ts
@@ -1,6 +1,28 @@
 import { PGlite } from '@electric-sql/pglite'
 import { vector } from '@electric-sql/pglite/vector'
 import { PGliteWorkerOptions, worker } from '@electric-sql/pglite/worker'
+import { ltree } from '@electric-sql/pglite/contrib/ltree'
+import { hstore } from '@electric-sql/pglite/contrib/hstore'
+import { earthdistance } from '@electric-sql/pglite/contrib/earthdistance'
+import { cube } from '@electric-sql/pglite/contrib/cube'
+import { citext } from '@electric-sql/pglite/contrib/citext'
+import { btree_gist } from '@electric-sql/pglite/contrib/btree_gist'
+import { btree_gin } from '@electric-sql/pglite/contrib/btree_gin'
+import { bloom } from '@electric-sql/pglite/contrib/bloom'
+import { lo } from '@electric-sql/pglite/contrib/lo'
+import { pg_trgm } from '@electric-sql/pglite/contrib/pg_trgm'
+import { seg } from '@electric-sql/pglite/contrib/seg'
+import { tablefunc } from '@electric-sql/pglite/contrib/tablefunc'
+import { tsm_system_time } from '@electric-sql/pglite/contrib/tsm_system_time'
+import { tsm_system_rows } from '@electric-sql/pglite/contrib/tsm_system_rows'
+import { uuid_ossp } from '@electric-sql/pglite/contrib/uuid_ossp'
+import { tcn } from '@electric-sql/pglite/contrib/tcn'
+import { isn } from '@electric-sql/pglite/contrib/isn'
+import { fuzzystrmatch } from '@electric-sql/pglite/contrib/fuzzystrmatch'
+import { auto_explain } from '@electric-sql/pglite/contrib/auto_explain'
+import { amcheck } from '@electric-sql/pglite/contrib/amcheck'
+import { adminpack } from '@electric-sql/pglite/contrib/adminpack'
+import { live } from '@electric-sql/pglite/live'
 
 worker({
   async init(options: PGliteWorkerOptions) {
@@ -9,7 +31,28 @@ worker({
       extensions: {
         ...options.extensions,
 
-        // vector extension needs to be passed directly in the worker vs. main thread
+        adminpack,
+        amcheck,
+        auto_explain,
+        bloom,
+        btree_gin,
+        btree_gist,
+        citext,
+        cube,
+        earthdistance,
+        fuzzystrmatch,
+        hstore,
+        isn,
+        live,
+        lo,
+        ltree,
+        pg_trgm,
+        seg,
+        tablefunc,
+        tcn,
+        tsm_system_rows,
+        tsm_system_time,
+        uuid_ossp,
         vector,
       },
     })


### PR DESCRIPTION
## What kind of change does this PR introduce?
Enables all supported extensions from https://pglite.dev/extensions/

## What is the current behavior?
See #82 

## What is the new behavior?
It can now successfully create schemas / run queries that make use of extensions.

![Screenshot from 2024-08-24 13-03-56](https://github.com/user-attachments/assets/31f38f22-c374-4f32-b4e6-486fbc2f1a4c)
![Screenshot from 2024-08-24 13-04-03](https://github.com/user-attachments/assets/49759595-1900-43a2-813f-be315e0f54f3)

## Additional context
I didn't add a migration to `CREATE EXTENSION ...` like is present for `pgvector` as I observed that the AI was able to figure out this is needed and do so on demand, which seems better.

There doesn't seem to be much overhead from doing this, but YMMV.