### PR TITLE
feat: site rename wording tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ In-browser Postgres sandbox with AI assistance.
 
 ![github-repo-hero](https://github.com/user-attachments/assets/1ace0688-dfa7-4ddb-86bc-c976fa5b2f42)
 
-With [database.build](https://database.build), you can instantly spin up an unlimited number of Postgres databases that run directly in your browser (and soon, deploy them to S3). 
+With [database.build](https://database.build), you can instantly spin up an unlimited number of Postgres databases that run directly in your browser (and soon, deploy them to S3).
 
 Each database is paired with a large language model (LLM) which opens the door to some interesting use cases:
 
@@ -14,6 +14,7 @@ Each database is paired with a large language model (LLM) which opens the door t
 - Build database diagrams
 
 ## How it works
+
 All queries in database.build run directly in your browser. There’s no remote Postgres container or WebSocket proxy.
 
 How is this possible? [PGlite](https://pglite.dev/), a WASM version of Postgres that can run directly in your browser. Every database that you create spins up a new instance of PGlite that exposes a fully-functional Postgres database. Data is stored in IndexedDB so that changes persist after refresh.
@@ -27,7 +28,7 @@ This is a monorepo split into the following projects:
 
 ## Why rename postgres.new?
 
-We renamed postgres.new due to a trademark conflict on the name "Postgres". To respect intellectual property rights, we are transitioning to our new name, database.build.
+This project is not an official Postgres project and we don’t want to mislead anyone! We’re renaming to database.build because, well, that’s what this does. This will still be 100% Postgres-focused, just with a different URL.
 
 ## Video
 

--- a/apps/postgres-new/app/export/page.tsx
+++ b/apps/postgres-new/app/export/page.tsx
@@ -57,13 +57,13 @@ export default function Page() {
                 </div>
               </AccordionTrigger>
               <AccordionContent className="p-3 prose prose-sm">
-                We are renaming {legacyDomainHostname} due to a trademark conflict on the name
-                &quot;Postgres&quot;. To respect intellectual property rights, we are transitioning
-                to our new name,{' '}
+                This project is not an official Postgres project and we don&apos;t want to mislead
+                anyone! We&apos;re renaming to{' '}
                 <Link href={currentDomainUrl} className="underline">
                   {currentDomainHostname}
-                </Link>
-                .
+                </Link>{' '}
+                because, well, that&apos;s what this does. This will still be 100% Postgres-focused,
+                just with a different URL.
               </AccordionContent>
             </AccordionItem>
           </Accordion>

--- a/apps/postgres-new/app/import/page.tsx
+++ b/apps/postgres-new/app/import/page.tsx
@@ -62,13 +62,13 @@ export default function Page() {
                 </div>
               </AccordionTrigger>
               <AccordionContent className="p-3 prose prose-sm">
-                We are renaming {legacyDomainHostname} due to a trademark conflict on the name
-                &quot;Postgres&quot;. To respect intellectual property rights, we are transitioning
-                to our new name,{' '}
+                This project is not an official Postgres project and we don&apos;t want to mislead
+                anyone! We&apos;re renaming to{' '}
                 <Link href={currentDomainUrl} className="underline">
                   {currentDomainHostname}
-                </Link>
-                .
+                </Link>{' '}
+                because, well, that&apos;s what this does. This will still be 100% Postgres-focused,
+                just with a different URL.
               </AccordionContent>
             </AccordionItem>
           </Accordion>

--- a/apps/postgres-new/components/layout.tsx
+++ b/apps/postgres-new/components/layout.tsx
@@ -91,13 +91,13 @@ function RenameDialog() {
         <h3 className="font-bold">Why rename?</h3>
 
         <p>
-          We are renaming {legacyDomainHostname} due to a trademark conflict on the name
-          &quot;Postgres&quot;. To respect intellectual property rights, we are transitioning to our
-          new name,{' '}
-          <a href={currentDomainUrl} className="underline">
+          This project is not an official Postgres project and we don&apos;t want to mislead anyone!
+          We&apos;re renaming to{' '}
+          <Link href={currentDomainUrl} className="underline">
             {currentDomainHostname}
-          </a>
-          .
+          </Link>{' '}
+          because, well, that&apos;s what this does. This will still be 100% Postgres-focused, just
+          with a different URL.
         </p>
 
         <div className="my-2 border-b" />


### PR DESCRIPTION
Adjusts wording around why postgres.new was renamed to database.build.

![image](https://github.com/user-attachments/assets/aa616fad-1b36-4ada-bcf6-c05eebcf1ea0)
