### PR TITLE
Fix SQL formatter causing page crashes

### DIFF
--- a/apps/postgres-new/components/ide.tsx
+++ b/apps/postgres-new/components/ide.tsx
@@ -2,21 +2,19 @@
 
 import { Editor } from '@monaco-editor/react'
 import { ParseResult } from 'libpg-query/wasm'
-import { FileCode, MessageSquareMore, Sprout, Workflow } from 'lucide-react'
+import { FileCode, MessageSquareMore, Workflow } from 'lucide-react'
 import { PropsWithChildren, useEffect, useState } from 'react'
-import { format } from 'sql-formatter'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/tabs'
 import { useMessagesQuery } from '~/data/messages/messages-query'
 import { useAsyncMemo } from '~/lib/hooks'
 import { tabsSchema, TabValue } from '~/lib/schema'
-import { assertDefined, isMigrationStatement } from '~/lib/sql-util'
+import { assertDefined, formatSql, isMigrationStatement } from '~/lib/sql-util'
 import { ToolInvocation } from '~/lib/tools'
 import { useBreakpoint } from '~/lib/use-breakpoint'
 import { cn } from '~/lib/utils'
-import { useApp } from './app-provider'
 import SchemaGraph from './schema/graph'
-import { useWorkspace } from './workspace'
 import { buttonVariants } from './ui/button'
+import { useWorkspace } from './workspace'
 
 const initialMigrationSql = '-- Migrations will appear here as you chat with AI\n'
 const initialSeedSql = '-- Seeds will appear here as you chat with AI\n'
@@ -80,13 +78,7 @@ export default function IDE({ children, className }: IDEProps) {
 
         const migrationSql = await deparse(filteredAst)
 
-        const formattedSql = format(migrationSql, {
-          language: 'postgresql',
-          keywordCase: 'lower',
-          identifierCase: 'lower',
-          dataTypeCase: 'lower',
-          functionCase: 'lower',
-        })
+        const formattedSql = formatSql(migrationSql) ?? sql
 
         const withSemicolon = formattedSql.endsWith(';') ? formattedSql : `${formattedSql};`
 
@@ -189,14 +181,11 @@ export default function IDE({ children, className }: IDEProps) {
                 monaco.languages.registerDocumentFormattingEditProvider('pgsql', {
                   async provideDocumentFormattingEdits(model) {
                     const currentCode = editor.getValue()
-                    const formattedCode = format(currentCode, {
-                      language: 'postgresql',
-                      keywordCase: 'lower',
-                    })
+                    const formattedCode = formatSql(currentCode)
                     return [
                       {
                         range: model.getFullModelRange(),
-                        text: formattedCode,
+                        text: formattedCode ?? currentCode,
                       },
                     ]
                   },
@@ -233,14 +222,11 @@ export default function IDE({ children, className }: IDEProps) {
                 monaco.languages.registerDocumentFormattingEditProvider('pgsql', {
                   async provideDocumentFormattingEdits(model) {
                     const currentCode = editor.getValue()
-                    const formattedCode = format(currentCode, {
-                      language: 'postgresql',
-                      keywordCase: 'lower',
-                    })
+                    const formattedCode = formatSql(currentCode)
                     return [
                       {
                         range: model.getFullModelRange(),
-                        text: formattedCode,
+                        text: formattedCode ?? currentCode,
                       },
                     ]
                   },

--- a/apps/postgres-new/components/tools/csv-export.tsx
+++ b/apps/postgres-new/components/tools/csv-export.tsx
@@ -1,8 +1,8 @@
 import { m } from 'framer-motion'
 import { Download } from 'lucide-react'
 import { useMemo } from 'react'
-import { format } from 'sql-formatter'
 import { loadFile } from '~/lib/files'
+import { formatSql } from '~/lib/sql-util'
 import { ToolInvocation } from '~/lib/tools'
 import { downloadFile } from '~/lib/util'
 import CodeAccordion from '../code-accordion'
@@ -14,17 +14,7 @@ export type CsvExportProps = {
 export default function CsvExport({ toolInvocation }: CsvExportProps) {
   const { sql } = toolInvocation.args
 
-  const formattedSql = useMemo(
-    () =>
-      format(sql, {
-        language: 'postgresql',
-        keywordCase: 'lower',
-        identifierCase: 'lower',
-        dataTypeCase: 'lower',
-        functionCase: 'lower',
-      }),
-    [sql]
-  )
+  const formattedSql = useMemo(() => formatSql(sql), [sql])
 
   if (!('result' in toolInvocation)) {
     return null
@@ -37,7 +27,7 @@ export default function CsvExport({ toolInvocation }: CsvExportProps) {
       <CodeAccordion
         title="Error executing SQL"
         language="sql"
-        code={formattedSql}
+        code={formattedSql ?? sql}
         error={result.error}
       />
     )
@@ -45,7 +35,7 @@ export default function CsvExport({ toolInvocation }: CsvExportProps) {
 
   return (
     <>
-      <CodeAccordion title="Executed SQL" language="sql" code={formattedSql} />
+      <CodeAccordion title="Executed SQL" language="sql" code={formattedSql ?? sql} />
       <m.div
         layoutId={toolInvocation.toolCallId}
         className="self-start px-5 py-2.5 text-base rounded-full bg-border flex gap-2 items-center text-lighter italic"

--- a/apps/postgres-new/components/tools/csv-import.tsx
+++ b/apps/postgres-new/components/tools/csv-import.tsx
@@ -1,7 +1,7 @@
+import { useMemo } from 'react'
+import { formatSql } from '~/lib/sql-util'
 import { ToolInvocation } from '~/lib/tools'
 import CodeAccordion from '../code-accordion'
-import { useMemo } from 'react'
-import { format } from 'sql-formatter'
 
 export type CsvExportProps = {
   toolInvocation: ToolInvocation<'importCsv'>
@@ -10,17 +10,7 @@ export type CsvExportProps = {
 export default function CsvImport({ toolInvocation }: CsvExportProps) {
   const { sql } = toolInvocation.args
 
-  const formattedSql = useMemo(
-    () =>
-      format(sql, {
-        language: 'postgresql',
-        keywordCase: 'lower',
-        identifierCase: 'lower',
-        dataTypeCase: 'lower',
-        functionCase: 'lower',
-      }),
-    [sql]
-  )
+  const formattedSql = useMemo(() => formatSql(sql), [sql])
 
   if (!('result' in toolInvocation)) {
     return null
@@ -33,11 +23,11 @@ export default function CsvImport({ toolInvocation }: CsvExportProps) {
       <CodeAccordion
         title="Error executing SQL"
         language="sql"
-        code={formattedSql}
+        code={formattedSql ?? sql}
         error={result.error}
       />
     )
   }
 
-  return <CodeAccordion title="Executed SQL" language="sql" code={formattedSql} />
+  return <CodeAccordion title="Executed SQL" language="sql" code={formattedSql ?? sql} />
 }

--- a/apps/postgres-new/components/tools/executed-sql.tsx
+++ b/apps/postgres-new/components/tools/executed-sql.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { format } from 'sql-formatter'
+import { formatSql } from '~/lib/sql-util'
 import { ToolInvocation } from '~/lib/tools'
 import CodeAccordion from '../code-accordion'
 
@@ -10,17 +10,7 @@ export type ExecutedSqlProps = {
 export default function ExecutedSql({ toolInvocation }: ExecutedSqlProps) {
   const { sql } = toolInvocation.args
 
-  const formattedSql = useMemo(
-    () =>
-      format(sql, {
-        language: 'postgresql',
-        keywordCase: 'lower',
-        identifierCase: 'lower',
-        dataTypeCase: 'lower',
-        functionCase: 'lower',
-      }),
-    [sql]
-  )
+  const formattedSql = useMemo(() => formatSql(sql), [sql])
 
   if (!('result' in toolInvocation)) {
     return null
@@ -33,11 +23,11 @@ export default function ExecutedSql({ toolInvocation }: ExecutedSqlProps) {
       <CodeAccordion
         title="Error executing SQL"
         language="sql"
-        code={formattedSql}
+        code={formattedSql ?? sql}
         error={result.error}
       />
     )
   }
 
-  return <CodeAccordion title="Executed SQL" language="sql" code={formattedSql} />
+  return <CodeAccordion title="Executed SQL" language="sql" code={formattedSql ?? sql} />
 }

--- a/apps/postgres-new/lib/hooks.ts
+++ b/apps/postgres-new/lib/hooks.ts
@@ -168,6 +168,7 @@ export function useAsyncMemo<T>(
       })
       .catch((err) => {
         if (!hasBeenCancelled.current) {
+          setValue(undefined)
           setError(err)
         }
       })

--- a/apps/postgres-new/lib/sql-util.ts
+++ b/apps/postgres-new/lib/sql-util.ts
@@ -1,4 +1,5 @@
 import { A_Const, A_Expr, ColumnRef, Node, RawStmt } from 'libpg-query/wasm'
+import { format } from 'sql-formatter'
 
 export function isQueryStatement(stmt: RawStmt) {
   return stmt.stmt && unwrapQueryStatement(stmt.stmt) !== undefined
@@ -505,5 +506,19 @@ export function parseConstant(constant: A_Const) {
     return constant.fval?.fval ? parseFloat(constant.fval.fval) : 0
   } else {
     throw new AssertionError(`Constant values must be a string, integer, or float`)
+  }
+}
+
+export function formatSql(sql: string) {
+  try {
+    return format(sql, {
+      language: 'postgresql',
+      keywordCase: 'lower',
+      identifierCase: 'lower',
+      dataTypeCase: 'lower',
+      functionCase: 'lower',
+    })
+  } catch (err) {
+    return undefined
   }
 }

--- a/apps/postgres-new/package.json
+++ b/apps/postgres-new/package.json
@@ -62,7 +62,7 @@
     "rehype-katex": "^7.0.0",
     "remark-gfm": "^4.0.0",
     "remark-math": "^6.0.0",
-    "sql-formatter": "^15.3.1",
+    "sql-formatter": "^15.4.5",
     "tailwind-merge": "^2.4.0",
     "tailwindcss-animate": "^1.0.7",
     "web-streams-polyfill": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,7 +130,7 @@
         "rehype-katex": "^7.0.0",
         "remark-gfm": "^4.0.0",
         "remark-math": "^6.0.0",
-        "sql-formatter": "^15.3.1",
+        "sql-formatter": "^15.4.5",
         "tailwind-merge": "^2.4.0",
         "tailwindcss-animate": "^1.0.7",
         "web-streams-polyfill": "^4.0.0",
@@ -12552,7 +12552,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/sql-formatter": {
-      "version": "15.3.2",
+      "version": "15.4.5",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-15.4.5.tgz",
+      "integrity": "sha512-dxYn0OzEmB19/9Y+yh8bqD8kJx2S/4pOTM4QLKxQDh7K6lp1Sx9MhmiF9RUJHSVjfV72KihW5R1h6Kecy6O5qA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",


### PR DESCRIPTION
### Problem
The SQL formatter we use (`sql-formatter`) crashes the page if it encounters SQL that it didn't expect. There are a few edge cases where valid SQL causes the formatter to throw an error. Since we called `format()` inside a React `useMemo()`, the component rendering failed and caused the page to crash.

<details>
  <summary>Example query that caused `sql-formatter` to throw</summary>

  ```sql
  WITH streaks AS (
      SELECT 
          time,
          close,
          LAG(close) OVER (ORDER BY time) AS prev_close,
          CASE WHEN close > LAG(close) OVER (ORDER BY time) THEN 1 ELSE 0 END AS is_green
      FROM nse_trent
  ),
  marked_streaks AS (
      SELECT 
          time,
          close,
          is_green,
          SUM(CASE WHEN is_green = 0 THEN 1 ELSE 0 END) OVER (ORDER BY time) AS streak_id
      FROM streaks
  ),
  winning_streaks AS (
      SELECT 
          MIN(time) AS start_date,
          MAX(time) AS end_date,
          COUNT(*) AS num_days,
          (MAX(close) - MIN(close)) / MIN(close) * 100 AS percentage_gain,
          MIN(close) AS start_price,
          MAX(close) AS end_price
      FROM marked_streaks
      WHERE is_green = 1
      GROUP BY streak_id
  )
  SELECT *
  FROM winning_streaks
  WHERE num_days > 3
  ORDER BY num_days DESC
  LIMIT 5;
  ```

</details>

### Solution
Wrap `format()` in a try-catch and fallback to the unformatted SQL if formatting fails. In the future we should look into either patching `sql-formatter` or use a different formatter.

Fixes #52 and #94 