### PR TITLE
feat: import sql files

### DIFF
--- a/apps/postgres-new/components/ide.tsx
+++ b/apps/postgres-new/components/ide.tsx
@@ -51,7 +51,9 @@ export default function IDE({ children, className }: IDEProps) {
           return toolInvocations
             .map((tool) =>
               // Only include SQL that successfully executed against the DB
-              tool.toolName === 'executeSql' && 'result' in tool && tool.result.success === true
+              (tool.toolName === 'executeSql' || tool.toolName === 'importSql') &&
+              'result' in tool &&
+              tool.result.success === true
                 ? tool.args.sql
                 : undefined
             )

--- a/apps/postgres-new/components/tools/index.tsx
+++ b/apps/postgres-new/components/tools/index.tsx
@@ -6,6 +6,8 @@ import CsvRequest from './csv-request'
 import ExecutedSql from './executed-sql'
 import GeneratedChart from './generated-chart'
 import GeneratedEmbedding from './generated-embedding'
+import SqlImport from './sql-import'
+import SqlRequest from './sql-request'
 
 export type ToolUiProps = {
   toolInvocation: ToolInvocation
@@ -23,6 +25,10 @@ export function ToolUi({ toolInvocation }: ToolUiProps) {
       return <CsvImport toolInvocation={toolInvocation} />
     case 'exportCsv':
       return <CsvExport toolInvocation={toolInvocation} />
+    case 'requestSql':
+      return <SqlRequest toolInvocation={toolInvocation} />
+    case 'importSql':
+      return <SqlImport toolInvocation={toolInvocation} />
     case 'renameConversation':
       return <ConversationRename toolInvocation={toolInvocation} />
     case 'embed':

--- a/apps/postgres-new/components/tools/sql-import.tsx
+++ b/apps/postgres-new/components/tools/sql-import.tsx
@@ -1,0 +1,33 @@
+import { useMemo } from 'react'
+import { formatSql } from '~/lib/sql-util'
+import { ToolInvocation } from '~/lib/tools'
+import CodeAccordion from '../code-accordion'
+
+export type SqlImportProps = {
+  toolInvocation: ToolInvocation<'importSql'>
+}
+
+export default function SqlImport({ toolInvocation }: SqlImportProps) {
+  const { fileId, sql } = toolInvocation.args
+
+  const formattedSql = useMemo(() => formatSql(sql), [sql])
+
+  if (!('result' in toolInvocation)) {
+    return null
+  }
+
+  const { result } = toolInvocation
+
+  if (!result.success) {
+    return (
+      <CodeAccordion
+        title="Error executing SQL"
+        language="sql"
+        code={formattedSql ?? sql}
+        error={result.error}
+      />
+    )
+  }
+
+  return <CodeAccordion title="Executed SQL" language="sql" code={formattedSql ?? sql} />
+}

--- a/apps/postgres-new/components/tools/sql-request.tsx
+++ b/apps/postgres-new/components/tools/sql-request.tsx
@@ -1,0 +1,114 @@
+import { generateId } from 'ai'
+import { useChat } from 'ai/react'
+import { m } from 'framer-motion'
+import { Paperclip } from 'lucide-react'
+import { loadFile, saveFile } from '~/lib/files'
+import { ToolInvocation } from '~/lib/tools'
+import { downloadFile } from '~/lib/util'
+import { useWorkspace } from '../workspace'
+
+export type SqlRequestProps = {
+  toolInvocation: ToolInvocation<'requestSql'>
+}
+
+export default function SqlRequest({ toolInvocation }: SqlRequestProps) {
+  const { databaseId } = useWorkspace()
+
+  const { addToolResult } = useChat({
+    id: databaseId,
+    api: '/api/chat',
+  })
+
+  if ('result' in toolInvocation) {
+    const { result } = toolInvocation
+
+    if (!result.success) {
+      return (
+        <m.div
+          layout="position"
+          layoutId={toolInvocation.toolCallId}
+          className="self-end px-5 py-2.5 text-base rounded-full bg-destructive flex gap-2 items-center text-lighter italic"
+        >
+          No SQL file selected
+        </m.div>
+      )
+    }
+
+    return (
+      <m.div
+        layout="position"
+        layoutId={toolInvocation.toolCallId}
+        className="self-end px-5 py-2.5 text-base rounded-full bg-border flex gap-2 items-center text-lighter italic"
+        style={{
+          // same value as tailwind, used to keep constant radius during framer animation
+          // see: https://www.framer.com/motion/layout-animations/##scale-correction
+          borderRadius: 9999,
+        }}
+      >
+        <Paperclip size={14} />
+        <m.span
+          className="cursor-pointer hover:underline"
+          layout
+          onClick={async () => {
+            const file = await loadFile(result.fileId)
+            downloadFile(file)
+          }}
+        >
+          {result.file.name}
+        </m.span>
+      </m.div>
+    )
+  }
+
+  return (
+    <m.div layout="position" layoutId={toolInvocation.toolCallId}>
+      <input
+        type="file"
+        onChange={async (e) => {
+          if (e.target.files) {
+            try {
+              const [file] = Array.from(e.target.files)
+
+              if (!file) {
+                throw new Error('No file found')
+              }
+
+              if (file.type !== 'text/sql') {
+                throw new Error('File is not a SQL file')
+              }
+
+              const fileId = generateId()
+
+              await saveFile(fileId, file)
+
+              const text = await file.text()
+
+              addToolResult({
+                toolCallId: toolInvocation.toolCallId,
+                result: {
+                  success: true,
+                  fileId: fileId,
+                  file: {
+                    name: file.name,
+                    size: file.size,
+                    type: file.type,
+                    lastModified: file.lastModified,
+                  },
+                  preview: text.split('\n').slice(0, 10).join('\n').trim(),
+                },
+              })
+            } catch (error) {
+              addToolResult({
+                toolCallId: toolInvocation.toolCallId,
+                result: {
+                  success: false,
+                  error: error instanceof Error ? error.message : 'An unknown error occurred',
+                },
+              })
+            }
+          }
+        }}
+      />
+    </m.div>
+  )
+}

--- a/apps/postgres-new/lib/files.ts
+++ b/apps/postgres-new/lib/files.ts
@@ -21,6 +21,18 @@ export async function hasFile(id: string) {
 }
 
 /**
+ * Reads a file as text.
+ */
+export function readFile(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = reject
+    reader.readAsText(file)
+  })
+}
+
+/**
  * Retrieves a file by ID.
  */
 export async function loadFile(id: string) {

--- a/apps/postgres-new/lib/files.ts
+++ b/apps/postgres-new/lib/files.ts
@@ -21,18 +21,6 @@ export async function hasFile(id: string) {
 }
 
 /**
- * Reads a file as text.
- */
-export function readFile(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader()
-    reader.onload = () => resolve(reader.result as string)
-    reader.onerror = reject
-    reader.readAsText(file)
-  })
-}
-
-/**
  * Retrieves a file by ID.
  */
 export async function loadFile(id: string) {

--- a/apps/postgres-new/lib/hooks.ts
+++ b/apps/postgres-new/lib/hooks.ts
@@ -440,7 +440,7 @@ export function useOnToolCall(databaseId: string) {
 
           try {
             const file = await loadFile(fileId)
-            await db.exec(await readFile(file))
+            await db.exec(await file.text())
             await refetchTables()
 
             return {

--- a/apps/postgres-new/lib/hooks.ts
+++ b/apps/postgres-new/lib/hooks.ts
@@ -18,7 +18,7 @@ import { useApp } from '~/components/app-provider'
 import { useDatabaseUpdateMutation } from '~/data/databases/database-update-mutation'
 import { useTablesQuery } from '~/data/tables/tables-query'
 import { embed } from './embed'
-import { loadFile, readFile, saveFile } from './files'
+import { loadFile, saveFile } from './files'
 import { SmoothScroller } from './smooth-scroller'
 import { maxRowLimit, OnToolCall } from './tools'
 

--- a/apps/postgres-new/lib/tools.ts
+++ b/apps/postgres-new/lib/tools.ts
@@ -162,6 +162,40 @@ export const tools = {
       })
     ),
   },
+  requestSql: {
+    description: codeBlock`
+      Requests a SQL file upload from the user.
+    `,
+    args: z.object({}),
+    result: result(
+      z.object({
+        fileId: z.string(),
+        file: z.object({
+          name: z.string(),
+          size: z.number(),
+          type: z.string(),
+          lastModified: z.number(),
+        }),
+        preview: z.string(),
+      })
+    ),
+  },
+  importSql: {
+    description: codeBlock`
+      Executes a Postgres SQL file with the specified ID against the user's database. Call \`requestSql\` first.
+    `,
+    args: z.object({
+      fileId: z.string().describe('The ID of the SQL file to execute'),
+      sql: z.string().describe(codeBlock`
+        The Postgres SQL file content to execute against the user's database.
+      `),
+    }),
+    result: result(
+      z.object({
+        message: z.string(),
+      })
+    ),
+  },
   embed: {
     description: codeBlock`
       Generates vector embeddings for texts. Use with pgvector extension.


### PR DESCRIPTION
Users can now drop or import `.sql` files into the chat.

The DDL statements executed as part of the `.sql` file will be recorded as migrations.

Demo:

https://github.com/user-attachments/assets/abf5557b-c0af-4510-b671-64ef51d3a10a

