### PR TITLE
Fix tool invocations in message import

### DIFF
--- a/apps/postgres-new/lib/db/index.ts
+++ b/apps/postgres-new/lib/db/index.ts
@@ -134,7 +134,7 @@ export class DbManager {
 
     const values = messages.map(
       (message) =>
-        sql`(${message.id}, ${message.databaseId}, ${message.role}, ${message.content}, ${message.toolInvocations ? JSON.stringify(message.toolInvocations) : raw`${null}`}, ${message.createdAt})`
+        sql`(${message.id}, ${message.databaseId}, ${message.role}, ${message.content}, ${message.toolInvocations}, ${message.createdAt})`
     )
 
     return metaDb.sql`insert into messages (id, database_id, role, content, tool_invocations, created_at) values ${join(values, ',')} on conflict (id) do nothing`


### PR DESCRIPTION
When importing databases into database.build (ie. from postgres.new), tool invocations fail to import correctly. This is related to changes to how PGlite serialized JSON columns in 0.2.7 vs. 0.2.8 (ie. you should no longer manually serialize JSON content via `JSON.stringify()` when saving data into a column - if you do, it will literally import as a string).

This was [caught](https://github.com/supabase-community/postgres-new/pull/103/commits/49da099d2b800807e3d34f143f94cbb65ede979c) in the Live Share branch at the time, but not in the export/import branch. This patch fixes the import logic to also remove `JSON.stringify()`.