### PR TITLE
improvement: lock databases across tabs and windows

### DIFF
--- a/apps/postgres-new/app/(main)/db/[id]/page.tsx
+++ b/apps/postgres-new/app/(main)/db/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 import { useApp } from '~/components/app-provider'
 import Workspace from '~/components/workspace'
+import { useDatabaseLock } from '~/lib/database-locks'
 
 export default function Page({ params }: { params: { id: string } }) {
   const databaseId = params.id
@@ -24,6 +25,12 @@ export default function Page({ params }: { params: { id: string } }) {
     }
     run()
   }, [dbManager, databaseId, router])
+
+  const isLocked = useDatabaseLock(databaseId)
+
+  if (isLocked) {
+    return <div>Database is locked</div>
+  }
 
   return <Workspace databaseId={databaseId} visibility="local" />
 }

--- a/apps/postgres-new/app/(main)/db/[id]/page.tsx
+++ b/apps/postgres-new/app/(main)/db/[id]/page.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-unescaped-entities */
 'use client'
 
+import NewDatabasePage from '../../page'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
@@ -32,24 +33,27 @@ export default function Page({ params }: { params: { id: string } }) {
 
   if (isLocked) {
     return (
-      <div className="h-full w-full flex items-center justify-center">
-        <p>
-          This database is already open in another tab or window.
-          <br />
-          <br />
-          Due to{' '}
-          <Link
-            target="_blank"
-            className="underline"
-            href="https://github.com/electric-sql/pglite?tab=readme-ov-file#how-it-works"
-          >
-            PGlite's single-user mode limitation
-          </Link>
-          , only one connection is allowed at a time.
-          <br />
-          <br />
-          Please close the database in the other location to access it here.
-        </p>
+      <div className="relative h-full w-full">
+        <NewDatabasePage />
+        <div className="absolute inset-0 bg-background/70 backdrop-blur-sm flex items-center justify-center">
+          <p>
+            This database is already open in another tab or window.
+            <br />
+            <br />
+            Due to{' '}
+            <Link
+              target="_blank"
+              className="underline"
+              href="https://github.com/electric-sql/pglite?tab=readme-ov-file#how-it-works"
+            >
+              PGlite's single-user mode limitation
+            </Link>
+            , only one connection is allowed at a time.
+            <br />
+            <br />
+            Please close the database in the other location to access it here.
+          </p>
+        </div>
       </div>
     )
   }

--- a/apps/postgres-new/app/(main)/db/[id]/page.tsx
+++ b/apps/postgres-new/app/(main)/db/[id]/page.tsx
@@ -1,5 +1,7 @@
+/* eslint-disable react/no-unescaped-entities */
 'use client'
 
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 import { useApp } from '~/components/app-provider'
@@ -29,7 +31,27 @@ export default function Page({ params }: { params: { id: string } }) {
   const isLocked = useDatabaseLock(databaseId)
 
   if (isLocked) {
-    return <div>Database is locked</div>
+    return (
+      <div className="h-full w-full flex items-center justify-center">
+        <p>
+          This database is already open in another tab or window.
+          <br />
+          <br />
+          Due to{' '}
+          <Link
+            target="_blank"
+            className="underline"
+            href="https://github.com/electric-sql/pglite?tab=readme-ov-file#how-it-works"
+          >
+            PGlite's single-user mode limitation
+          </Link>
+          , only one connection is allowed at a time.
+          <br />
+          <br />
+          Please close the database in the other location to access it here.
+        </p>
+      </div>
+    )
   }
 
   return <Workspace databaseId={databaseId} visibility="local" />

--- a/apps/postgres-new/components/providers.tsx
+++ b/apps/postgres-new/components/providers.tsx
@@ -5,9 +5,17 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { PropsWithChildren } from 'react'
 import AppProvider from './app-provider'
 import { ThemeProvider } from './theme-provider'
-import { DatabaseLocksProvider } from '~/lib/database-locks'
 
 const queryClient = new QueryClient()
+
+import dynamic from 'next/dynamic'
+
+const DatabaseLocksProvider = dynamic(
+  async () => (await import('~/lib/database-locks')).DatabaseLocksProvider,
+  {
+    ssr: false,
+  }
+)
 
 export default function Providers({ children }: PropsWithChildren) {
   return (

--- a/apps/postgres-new/components/providers.tsx
+++ b/apps/postgres-new/components/providers.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { PropsWithChildren } from 'react'
 import AppProvider from './app-provider'
 import { ThemeProvider } from './theme-provider'
+import { DatabaseLocksProvider } from '~/lib/database-locks'
 
 const queryClient = new QueryClient()
 
@@ -12,7 +13,9 @@ export default function Providers({ children }: PropsWithChildren) {
   return (
     <ThemeProvider attribute="class" defaultTheme="system" disableTransitionOnChange>
       <QueryClientProvider client={queryClient}>
-        <AppProvider>{children}</AppProvider>
+        <AppProvider>
+          <DatabaseLocksProvider>{children}</DatabaseLocksProvider>
+        </AppProvider>
       </QueryClientProvider>
     </ThemeProvider>
   )

--- a/apps/postgres-new/components/sidebar.tsx
+++ b/apps/postgres-new/components/sidebar.tsx
@@ -43,6 +43,7 @@ import {
 } from './ui/dropdown-menu'
 import { TooltipPortal } from '@radix-ui/react-tooltip'
 import { LiveShareIcon } from './live-share-icon'
+import { useIsLocked } from '~/lib/database-locks'
 
 export default function Sidebar() {
   const {
@@ -299,6 +300,7 @@ type DatabaseMenuItemProps = {
 function DatabaseMenuItem({ database, isActive }: DatabaseMenuItemProps) {
   const router = useRouter()
   const { user, dbManager, liveShare } = useApp()
+  const isLocked = useIsLocked(database.id)
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
   const { mutateAsync: deleteDatabase } = useDatabaseDeleteMutation()
   const { mutateAsync: updateDatabase } = useDatabaseUpdateMutation()
@@ -446,6 +448,7 @@ function DatabaseMenuItem({ database, isActive }: DatabaseMenuItemProps) {
             ) : (
               <div className="flex flex-col items-stretch w-32">
                 <DropdownMenuItem
+                  disabled={isLocked}
                   className="gap-3"
                   onSelect={async (e) => {
                     e.preventDefault()
@@ -460,6 +463,7 @@ function DatabaseMenuItem({ database, isActive }: DatabaseMenuItemProps) {
                   <span>Rename</span>
                 </DropdownMenuItem>
                 <DropdownMenuItem
+                  disabled={isLocked}
                   className="gap-3"
                   onSelect={async (e) => {
                     e.preventDefault()
@@ -493,7 +497,7 @@ function DatabaseMenuItem({ database, isActive }: DatabaseMenuItemProps) {
                     setIsDeployDialogOpen(true)
                     setIsPopoverOpen(false)
                   }}
-                  disabled={user === undefined}
+                  disabled={user === undefined || isLocked}
                 >
                   <Upload
                     size={16}
@@ -506,9 +510,11 @@ function DatabaseMenuItem({ database, isActive }: DatabaseMenuItemProps) {
                   databaseId={database.id}
                   isActive={isActive}
                   setIsPopoverOpen={setIsPopoverOpen}
+                  disabled={user === undefined || isLocked}
                 />
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
+                  disabled={isLocked}
                   className="gap-3"
                   onSelect={async (e) => {
                     e.preventDefault()
@@ -539,11 +545,12 @@ function DatabaseMenuItem({ database, isActive }: DatabaseMenuItemProps) {
 type ConnectMenuItemProps = {
   databaseId: string
   isActive: boolean
+  disabled?: boolean
   setIsPopoverOpen: (open: boolean) => void
 }
 
 function LiveShareMenuItem(props: ConnectMenuItemProps) {
-  const { liveShare, user } = useApp()
+  const { liveShare } = useApp()
   const router = useRouter()
 
   if (liveShare.isLiveSharing && liveShare.databaseId === props.databaseId) {
@@ -564,7 +571,7 @@ function LiveShareMenuItem(props: ConnectMenuItemProps) {
 
   return (
     <DropdownMenuItem
-      disabled={!user}
+      disabled={props.disabled}
       className="bg-inherit justify-start hover:bg-neutral-200 flex gap-3"
       onClick={async (e) => {
         e.preventDefault()

--- a/apps/postgres-new/lib/database-locks.tsx
+++ b/apps/postgres-new/lib/database-locks.tsx
@@ -125,7 +125,6 @@ export function useDatabaseLock(databaseId: string) {
         const isAvailable = !(databaseId in newLocks)
 
         if (isAvailable) {
-          console.log('Database became available, acquiring lock:', databaseId)
           acquireLock(databaseId)
         }
       }

--- a/apps/postgres-new/lib/database-locks.tsx
+++ b/apps/postgres-new/lib/database-locks.tsx
@@ -141,3 +141,15 @@ export function useDatabaseLock(databaseId: string) {
 
   return isLocked
 }
+
+export function useIsLocked(databaseId: string) {
+  const context = useContext(DatabaseLocksContext)
+  const tabId = getTabId()
+
+  if (!context) {
+    throw new Error('useIsLocked must be used within a DatabaseLocksProvider')
+  }
+
+  const { locks } = context
+  return locks[databaseId] !== undefined && locks[databaseId] !== tabId
+}

--- a/apps/postgres-new/lib/database-locks.tsx
+++ b/apps/postgres-new/lib/database-locks.tsx
@@ -1,0 +1,143 @@
+import { createContext, useCallback, useContext, useEffect, useState } from 'react'
+
+type DatabaseLocks = {
+  [databaseId: string]: string // databaseId -> tabId mapping
+}
+
+function getTabId() {
+  const stored = sessionStorage.getItem('tabId')
+  if (stored) return stored
+
+  const newId = crypto.randomUUID()
+  sessionStorage.setItem('tabId', newId)
+  return newId
+}
+
+const DatabaseLocksContext = createContext<{
+  locks: DatabaseLocks
+  acquireLock: (databaseId: string) => void
+  releaseLock: (databaseId: string) => void
+}>({
+  locks: {},
+  acquireLock: () => {},
+  releaseLock: () => {},
+})
+
+export function DatabaseLocksProvider({ children }: { children: React.ReactNode }) {
+  const tabId = getTabId()
+  const lockKey = 'dbLocks'
+
+  // Initialize with current localStorage state
+  const [locks, setLocks] = useState<DatabaseLocks>(() =>
+    JSON.parse(localStorage.getItem(lockKey) || '{}')
+  )
+
+  const acquireLock = useCallback(
+    (databaseId: string) => {
+      const currentLocks = JSON.parse(localStorage.getItem(lockKey) || '{}') as DatabaseLocks
+
+      if (!(databaseId in currentLocks)) {
+        const newLocks = { ...currentLocks, [databaseId]: tabId }
+        localStorage.setItem(lockKey, JSON.stringify(newLocks))
+        setLocks(newLocks)
+      }
+    },
+    [tabId]
+  )
+
+  const releaseLock = useCallback(
+    (databaseId: string) => {
+      const currentLocks = JSON.parse(localStorage.getItem(lockKey) || '{}') as DatabaseLocks
+
+      if (currentLocks[databaseId] === tabId) {
+        const { [databaseId]: _, ...newLocks } = currentLocks
+
+        if (Object.keys(newLocks).length === 0) {
+          localStorage.removeItem(lockKey)
+        } else {
+          localStorage.setItem(lockKey, JSON.stringify(newLocks))
+        }
+
+        setLocks(newLocks)
+      }
+    },
+    [tabId]
+  )
+
+  useEffect(() => {
+    const handleStorageChange = (event: StorageEvent) => {
+      if (event.key === lockKey) {
+        setLocks(JSON.parse(event.newValue || '{}'))
+      }
+    }
+
+    window.addEventListener('storage', handleStorageChange)
+
+    const handleBeforeUnload = () => {
+      const currentLocks = JSON.parse(localStorage.getItem(lockKey) || '{}') as DatabaseLocks
+      const newLocks: DatabaseLocks = {}
+
+      for (const [dbId, lockingTabId] of Object.entries(currentLocks)) {
+        if (lockingTabId !== tabId) {
+          newLocks[dbId] = lockingTabId
+        }
+      }
+
+      if (Object.keys(newLocks).length === 0) {
+        localStorage.removeItem(lockKey)
+      } else {
+        localStorage.setItem(lockKey, JSON.stringify(newLocks))
+      }
+    }
+
+    window.addEventListener('beforeunload', handleBeforeUnload)
+
+    return () => {
+      window.removeEventListener('storage', handleStorageChange)
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+    }
+  }, [lockKey, tabId])
+
+  return (
+    <DatabaseLocksContext.Provider value={{ locks, acquireLock, releaseLock }}>
+      {children}
+    </DatabaseLocksContext.Provider>
+  )
+}
+
+export function useDatabaseLock(databaseId: string) {
+  const context = useContext(DatabaseLocksContext)
+  const tabId = getTabId()
+
+  if (!context) {
+    throw new Error('useDatabaseLock must be used within a DatabaseLocksProvider')
+  }
+
+  const { locks, acquireLock, releaseLock } = context
+  const isLocked = locks[databaseId] !== undefined && locks[databaseId] !== tabId
+
+  useEffect(() => {
+    acquireLock(databaseId)
+
+    const handleStorageChange = (event: StorageEvent) => {
+      if (event.key === 'dbLocks') {
+        const newLocks = JSON.parse(event.newValue || '{}') as DatabaseLocks
+        const isAvailable = !(databaseId in newLocks)
+
+        if (isAvailable) {
+          console.log('Database became available, acquiring lock:', databaseId)
+          acquireLock(databaseId)
+        }
+      }
+    }
+
+    window.addEventListener('storage', handleStorageChange)
+
+    return () => {
+      releaseLock(databaseId)
+      window.removeEventListener('storage', handleStorageChange)
+    }
+  }, [databaseId, acquireLock, releaseLock])
+
+  return isLocked
+}


### PR DESCRIPTION
Databases are now only usable in a single tab or window.

This is necessary due to PGlite single-user mode limitation to avoid race conditions if the user sends multiple queries from different locations. The postgres wire messages could be mixed resulting in unpredictable behaviours.

Web API features used to make it works:
- `sessionStorage` to identify each tab/window with a unique id.
- `localStorage` to store the locks between tabs and windows.
- `window.addEventListener('storage', ...)` to listen to changes and synchronize each tab/window context state.
- `window.addEventListener('beforeunload', ...)` to clear the lock if the tab or window is closed.

Demo:

https://github.com/user-attachments/assets/f8df6e3b-f270-4932-acde-fc249a0ec28d

