### PR TITLE
feat(telemetry): tool result name and success

### DIFF
--- a/apps/postgres-new/utils/telemetry.ts
+++ b/apps/postgres-new/utils/telemetry.ts
@@ -13,6 +13,11 @@ export type ChatRateLimitEvent = {
   }
 }
 
+export type ChatInferenceEventToolResult = {
+  toolName: string
+  success: boolean
+}
+
 /**
  * Event for an AI chat inference request-response.
  * Includes both input and output metadata.
@@ -24,6 +29,7 @@ export type ChatInferenceEvent = {
     userId: string
     messageCount: number
     inputType: 'user-message' | 'tool-result'
+    toolResults?: ChatInferenceEventToolResult[]
     inputTokens: number
     outputTokens: number
     finishReason:


### PR DESCRIPTION
Adds `toolResults` field to inference telemetry to track the name of the tool that was invoked and whether or not it was successful. Since LLMs can accept multiple tool results in a single message, this is an array. It will be undefined if the input message was not a tool result.

As always no actual content (like args or result message) is sent for privacy reasons.

Example toolResults field:
```
{
  ...
  toolResults: [
    { toolName: 'executeSql', success: true },
  ],
  ...
}
```