### PR TITLE
fix: require authenticated user for deployment queries

### DIFF
--- a/apps/web/data/deploy-waitlist/deploy-waitlist-query.ts
+++ b/apps/web/data/deploy-waitlist/deploy-waitlist-query.ts
@@ -1,13 +1,16 @@
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { createClient } from '~/utils/supabase/client'
+import { useApp } from '~/components/app-provider'
 
 export const useIsOnDeployWaitlistQuery = (
   options: Omit<UseQueryOptions<boolean, Error>, 'queryKey' | 'queryFn'> = {}
 ) => {
   const supabase = createClient()
+  const { user } = useApp()
 
   return useQuery<boolean, Error>({
     ...options,
+    enabled: options.enabled !== undefined ? options.enabled : !!user,
     queryKey: getIsOnDeployWaitlistQueryKey(),
     queryFn: async () => {
       const { data, error } = await supabase.auth.getUser()

--- a/apps/web/data/deployed-databases/deployed-databases-query.ts
+++ b/apps/web/data/deployed-databases/deployed-databases-query.ts
@@ -1,5 +1,6 @@
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { createClient } from '~/utils/supabase/client'
+import { useApp } from '~/components/app-provider'
 
 export type DeployedDatabase = Awaited<ReturnType<typeof getDeployedDatabases>>[number]
 
@@ -21,8 +22,11 @@ async function getDeployedDatabases() {
 export const useDeployedDatabasesQuery = (
   options: Omit<UseQueryOptions<DeployedDatabase[], Error>, 'queryKey' | 'queryFn'> = {}
 ) => {
+  const { user } = useApp()
+
   return useQuery<DeployedDatabase[], Error>({
     ...options,
+    enabled: options.enabled !== undefined ? options.enabled : !!user,
     queryKey: getDeployedDatabasesQueryKey(),
     queryFn: async () => {
       return await getDeployedDatabases()

--- a/apps/web/data/integrations/integration-query.ts
+++ b/apps/web/data/integrations/integration-query.ts
@@ -1,6 +1,7 @@
 import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { IntegrationDetails } from '~/app/api/integrations/[id]/details/route'
 import { createClient } from '~/utils/supabase/client'
+import { useApp } from '~/components/app-provider'
 
 async function getIntegrationDetails(id: number): Promise<IntegrationDetails> {
   const response = await fetch(`/api/integrations/${id}/details`)
@@ -33,8 +34,11 @@ export const useIntegrationQuery = (
   name: string,
   options: Omit<UseQueryOptions<IntegrationDetails, Error>, 'queryKey' | 'queryFn'> = {}
 ) => {
+  const { user } = useApp()
+
   return useQuery<IntegrationDetails, Error>({
     ...options,
+    enabled: options.enabled !== undefined ? options.enabled : !!user,
     queryKey: getIntegrationQueryKey(name),
     queryFn: async () => {
       const { id } = await getIntegration(name)


### PR DESCRIPTION
Fixes #157

## Summary
Added proper authentication checks using \useApp\ in the relevant React Query hooks for deployed databases, integrations, and deploy waitlist queries to ensure that they are only executed when a valid user session is detected. This prevents unwanted unauthenticated requests.