### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/apps/web/components/model-provider/set-model-provider-dialog.tsx
+++ b/apps/web/components/model-provider/set-model-provider-dialog.tsx
@@ -132,6 +132,15 @@ function SetModelProviderForm(props: { id: string; onSubmit: (values: FormSchema
                       >
                         OpenRouter
                       </MiniButton>
+                      <MiniButton
+                        onClick={(e) => {
+                          e.preventDefault()
+                          form.setValue('baseUrl', getProviderUrl('litellm'))
+                          form.setValue('model', 'openai/gpt-4o-mini')
+                        }}
+                      >
+                        LiteLLM
+                      </MiniButton>
                     </div>
                   </>
                 </FormControl>

--- a/apps/web/lib/llm-provider.ts
+++ b/apps/web/lib/llm-provider.ts
@@ -2,6 +2,7 @@ const providerUrlMap = new Map([
   ['openai', 'https://api.openai.com/v1'],
   ['x-ai', 'https://api.x.ai/v1'],
   ['openrouter', 'https://openrouter.ai/api/v1'],
+  ['litellm', 'http://localhost:4000/v1'],
 ] as const)
 
 type MapKeys<T> = T extends Map<infer K, any> ? K : never


### PR DESCRIPTION


## What kind of change does this PR introduce?

Feature - adds [LiteLLM](https://github.com/BerriAI/litellm) as a new provider option for the model provider dialog, enabling routing to 100+ LLM providers via a single proxy.

## What is the current behavior?

The model provider dialog offers three quick-select providers: OpenAI, xAI, and OpenRouter. Users who want to use other providers (AWS Bedrock, Vertex AI, Mistral, Cohere, etc.) must manually enter their base URLs.

## What is the new behavior?

A "LiteLLM" button is added alongside the existing provider buttons. Clicking it auto-fills:
- Base URL: `http://localhost:4000/v1` (editable to any deployed LiteLLM proxy)
- Model: `openai/gpt-4o-mini` (editable to any LiteLLM model ID like `anthropic/claude-3-5-sonnet`, `azure/gpt-4`, `bedrock/anthropic.claude-3`, etc.)

**Changes:**
- `apps/web/lib/llm-provider.ts` - added `litellm` to `providerUrlMap`
- `apps/web/components/model-provider/set-model-provider-dialog.tsx` - added LiteLLM quick-select button

**Live E2E verified** - LiteLLM proxy routing to Claude Sonnet 4.6:

    Model: claude-sonnet-4-6
    Content: OK
    Finish: stop

## Additional context

LiteLLM is an AI gateway that provides a unified OpenAI-compatible API for 100+ providers. The service worker already uses `createOpenAI({ baseURL })` for all providers, so LiteLLM works out of the box - no new dependencies needed. 2 files changed, 10 lines added, fully additive.
